### PR TITLE
add: `Promise` getters to `KurtResult`, for convenience.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ for await (const event of stream) {
 //   text: "Hello! How can I assist you today?",
 //   data: undefined,
 // }
+
+await stream.finalText // "Hello! How can I assist you today?"
 ```
 
 ## Generate Structured Data Output
@@ -88,4 +90,6 @@ for await (const event of stream) {
 // { chunk: "hello" }
 // { chunk: '"}' }
 // { finished: true, text: '{"say":"hello"}', data: { say: "hello" } }
+
+await stream.finalData // { say: "hello" }
 ```

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@jest/globals": "^29.7.0",
 		"jest": "^29.7.0",
 		"ts-jest": "^29.1.2",
+		"type-fest": "^4.18.1",
 		"typescript": "^5.4.5"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       ts-jest:
         specifier: ^29.1.2
         version: 29.1.2(@babel/core@7.24.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.5))(jest@29.7.0(@types/node@18.19.31))(typescript@5.4.5)
+      type-fest:
+        specifier: ^4.18.1
+        version: 4.18.1
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -1258,6 +1261,10 @@ packages:
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
+
+  type-fest@4.18.1:
+    resolution: {integrity: sha512-qXhgeNsX15bM63h5aapNFcQid9jRF/l3ojDoDFmekDQEUufZ9U4ErVt6SjDxnHp48Ltrw616R8yNc3giJ3KvVQ==}
+    engines: {node: '>=16'}
 
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
@@ -2865,6 +2872,8 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@4.18.1: {}
 
   typescript@5.4.5: {}
 

--- a/spec/KurtResult.spec.ts
+++ b/spec/KurtResult.spec.ts
@@ -1,0 +1,266 @@
+import { describe, test, expect, jest } from "@jest/globals"
+import { KurtResult, KurtResultEvent } from "../src/KurtResult"
+import { z } from "zod"
+
+function kurtSayHelloEvents() {
+  return [
+    { chunk: '{"' },
+    { chunk: "say" },
+    { chunk: '":"' },
+    { chunk: "hello" },
+    { chunk: '"}' },
+    {
+      finished: true,
+      text: '{"say":"hello"}',
+      data: { say: "hello" },
+    },
+  ]
+}
+
+function kurtSayHelloFinalEvent() {
+  const events = kurtSayHelloEvents()
+  return events[events.length - 1]!
+}
+
+function kurtResultSayHello(
+  opts: {
+    errorBeforeFinish?: boolean
+  } = {}
+) {
+  const schema = z.object({ say: z.string() })
+  return new KurtResult<(typeof schema)["shape"]>(
+    (async function* gen() {
+      const events = kurtSayHelloEvents()
+
+      for (const event of events) {
+        // Wait a bit before sending the event, so we can interleave things.
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        // Throw an error before finishing, if requested.
+        if (opts.errorBeforeFinish && event.finished) throw new Error("Whoops!")
+
+        // Send the event.
+        yield event as KurtResultEvent<(typeof schema)["shape"]>
+      }
+    })()
+  )
+}
+
+async function expectThrow(message: string, fn: () => Promise<unknown>) {
+  let error: unknown
+  try {
+    await fn()
+  } catch (e: unknown) {
+    error = e
+  }
+  expect(error).toBeInstanceOf(Error)
+  expect((error as Error).message).toBe(message)
+}
+
+describe("KurtResult", () => {
+  test("with an await for final text", async () => {
+    const result = kurtResultSayHello()
+
+    expect(await result.finalText).toEqual(kurtSayHelloFinalEvent().text)
+  })
+
+  test("with an await for final data", async () => {
+    const result = kurtResultSayHello()
+
+    expect(await result.finalData).toEqual(kurtSayHelloFinalEvent().data)
+  })
+
+  test("with an await for final event", async () => {
+    const result = kurtResultSayHello()
+
+    expect(await result.finalEvent).toEqual(kurtSayHelloFinalEvent())
+  })
+
+  test("with an await for final event catching an error", async () => {
+    const result = kurtResultSayHello({ errorBeforeFinish: true })
+
+    expectThrow("Whoops!", async () => await result.finalEvent)
+  })
+
+  test("with one event listener", async () => {
+    const result = kurtResultSayHello()
+
+    const events: unknown[] = []
+    for await (const event of result) events.push(event)
+
+    expect(events).toEqual(kurtSayHelloEvents())
+  })
+
+  test("with one event listener, catching an error", async () => {
+    const result = kurtResultSayHello({ errorBeforeFinish: true })
+
+    const events: unknown[] = []
+    await expectThrow("Whoops!", async () => {
+      for await (const event of result) events.push(event)
+    })
+
+    expect(events).toEqual(kurtSayHelloEvents().slice(0, -1))
+  })
+
+  test("with final awaits before listener", async () => {
+    const result = kurtResultSayHello()
+
+    expect(await result.finalEvent).toEqual(kurtSayHelloFinalEvent())
+    expect(await result.finalText).toEqual(kurtSayHelloFinalEvent().text)
+    expect(await result.finalData).toEqual(kurtSayHelloFinalEvent().data)
+
+    const events: unknown[] = []
+    for await (const event of result) events.push(event)
+
+    expect(events).toEqual(kurtSayHelloEvents())
+  })
+
+  test("with final awaits after listener", async () => {
+    const result = kurtResultSayHello()
+
+    const events: unknown[] = []
+    for await (const event of result) events.push(event)
+
+    expect(await result.finalEvent).toEqual(kurtSayHelloFinalEvent())
+    expect(await result.finalText).toEqual(kurtSayHelloFinalEvent().text)
+    expect(await result.finalData).toEqual(kurtSayHelloFinalEvent().data)
+
+    expect(events).toEqual(kurtSayHelloEvents())
+  })
+
+  test("with three listeners, each after the last one finished", async () => {
+    const result = kurtResultSayHello()
+
+    const events1: unknown[] = []
+    const events2: unknown[] = []
+    const events3: unknown[] = []
+    for await (const event of result) events1.push(event)
+    for await (const event of result) events2.push(event)
+    for await (const event of result) events3.push(event)
+
+    expect(events1).toEqual(kurtSayHelloEvents())
+    expect(events2).toEqual(kurtSayHelloEvents())
+    expect(events2).toEqual(kurtSayHelloEvents())
+  })
+
+  test("with three listeners, each catching an error", async () => {
+    const result = kurtResultSayHello({ errorBeforeFinish: true })
+
+    const events1: unknown[] = []
+    const events2: unknown[] = []
+    const events3: unknown[] = []
+    await expectThrow("Whoops!", async () => {
+      for await (const event of result) events1.push(event)
+    })
+    await expectThrow("Whoops!", async () => {
+      for await (const event of result) events2.push(event)
+    })
+    await expectThrow("Whoops!", async () => {
+      for await (const event of result) events3.push(event)
+    })
+
+    expect(events1).toEqual(kurtSayHelloEvents().slice(0, -1))
+    expect(events2).toEqual(kurtSayHelloEvents().slice(0, -1))
+    expect(events2).toEqual(kurtSayHelloEvents().slice(0, -1))
+  })
+
+  test("with many listeners, interleaved with one another", async () => {
+    const result = kurtResultSayHello()
+
+    const events: unknown[][] = []
+    const listeners: Promise<unknown>[] = []
+    async function listen(spawnMoreListeners = false) {
+      events.push([])
+      const listenerIndex = events.length - 1
+      for await (const event of result) {
+        events[listenerIndex]!.push(event)
+        if (spawnMoreListeners) listeners.push(listen())
+      }
+    }
+    listeners.push(listen(true))
+
+    let lastListenerCount = 0
+    while (listeners.length !== lastListenerCount) {
+      lastListenerCount = listeners.length
+      await Promise.all(listeners)
+    }
+
+    expect(events.length).toBe(7)
+    events.forEach((e) => {
+      expect(e).toEqual(kurtSayHelloEvents())
+    })
+  })
+
+  test("with many listeners, interleaved with final event awaits", async () => {
+    const result = kurtResultSayHello()
+
+    const events: unknown[][] = []
+    const listeners: Promise<unknown>[] = []
+    const awaits: Promise<unknown>[] = []
+    async function listen(spawnMoreListeners = false) {
+      events.push([])
+      const listenerIndex = events.length - 1
+      for await (const event of result) {
+        events[listenerIndex]!.push(event)
+        if (spawnMoreListeners) {
+          listeners.push(listen())
+          awaits.push(
+            (async () =>
+              expect(await result.finalEvent).toEqual(
+                kurtSayHelloFinalEvent()
+              ))()
+          )
+        }
+      }
+    }
+    listeners.push(listen(true))
+
+    let lastListenerCount = 0
+    while (listeners.length !== lastListenerCount) {
+      lastListenerCount = listeners.length
+      await Promise.all(listeners)
+    }
+    await Promise.all(awaits)
+
+    expect(events.length).toBe(7)
+    events.forEach((e) => {
+      expect(e).toEqual(kurtSayHelloEvents())
+    })
+  })
+
+  test("with many listeners/awaits, interleaved, with error", async () => {
+    const result = kurtResultSayHello({ errorBeforeFinish: true })
+
+    const events: unknown[][] = []
+    const listeners: Promise<unknown>[] = []
+    const errorers: Promise<unknown>[] = []
+    async function listen(spawnMoreListeners = false) {
+      events.push([])
+      const listenerIndex = events.length - 1
+      for await (const event of result) {
+        events[listenerIndex]!.push(event)
+        if (spawnMoreListeners) {
+          const listener = listen()
+          listeners.push(listener)
+          errorers.push(expectThrow("Whoops!", async () => await listener))
+          errorers.push(
+            expectThrow("Whoops!", async () => await result.finalEvent)
+          )
+        }
+      }
+    }
+    listeners.push(listen(true))
+
+    let lastListenerCount = 0
+    while (listeners.length !== lastListenerCount) {
+      lastListenerCount = listeners.length
+      await expectThrow("Whoops!", async () => await Promise.all(listeners))
+    }
+    await Promise.all(errorers)
+
+    expect(events.length).toBe(6)
+    events.forEach((e) => {
+      expect(e).toEqual(kurtSayHelloEvents().slice(0, -1))
+    })
+  })
+})

--- a/src/KurtResult.ts
+++ b/src/KurtResult.ts
@@ -1,24 +1,184 @@
+import type { Promisable } from "type-fest"
 import { KurtSchemaInnerMaybe, KurtSchemaResultMaybe } from "./KurtSchema"
 
+export type KurtResultEventChunk = { chunk: string }
+export type KurtResultEventFinal<T extends KurtSchemaInnerMaybe = undefined> = {
+  finished: true
+  text: string
+  data: KurtSchemaResultMaybe<T>
+}
 export type KurtResultEvent<T extends KurtSchemaInnerMaybe = undefined> =
-  | {
-      chunk: string
-    }
-  | {
-      finished: true
-      text: string
-      data: KurtSchemaResultMaybe<T>
-    }
+  | KurtResultEventChunk
+  | KurtResultEventFinal<T>
 
+type _AdditionalListener<T extends KurtSchemaInnerMaybe = undefined> = (
+  event: KurtResultEvent<T> | { uncaughtError: unknown }
+) => void
+
+// This class represents the result of a call to an LLM.
+//
+// It acts as an AsyncIterable, so that the caller can observe a stream of
+// events (with a common interface across any supported LLM).
+//
+// The events are buffered such that multiple listeners can all observe
+// the stream, without disrupting one anothers' view of events, such that
+// each listener will see exactly the same stream of events, regardless
+// of when each one started listening.
+//
+// It also exposes a few convenience getters for callers who are only
+// interested in the final result event, or the text/data from that event.
 export class KurtResult<T extends KurtSchemaInnerMaybe = undefined>
   implements AsyncIterable<KurtResultEvent<T>>
 {
-  constructor(private gen: AsyncGenerator<KurtResultEvent<T>>) {}
+  private started: boolean = false
+  private finished: boolean = false
+  private seenEvents: KurtResultEvent<T>[] = []
+  private additionalListeners = new Set<_AdditionalListener<T>>()
+  private finalEventValue?: KurtResultEventFinal<T>
+  private finalEventPromise: Promise<KurtResultEventFinal<T>>
+  private finalEventResolve!: (e: Promisable<KurtResultEventFinal<T>>) => void
+  private finalEventReject!: (reason?: unknown) => void
 
+  // Create a new result stream, from the given underlying stream generator.
+  constructor(private gen: AsyncGenerator<KurtResultEvent<T>>) {
+    this.finalEventPromise = new Promise((resolve, reject) => {
+      this.finalEventResolve = resolve
+      this.finalEventReject = reject
+    })
+  }
+
+  // Get the final event from the end of the result stream, when it is ready.
+  get finalEvent(): Promise<KurtResultEventFinal<T>> {
+    return this._finalEvent()
+  }
+  private async _finalEvent() {
+    // If nobody has started listening to the stream yet, we need to be
+    // the first listener of it. This makes sure we will eventually fulfill
+    // the promise that we are about to await on.
+    if (!this.started) for await (const _ of this) null
+
+    // Now wait for the underlying promise to fulfill.
+    return this.finalEventPromise
+  }
+
+  // Get the text from the end of the result stream, when it is ready.
+  get finalText(): Promise<string> {
+    return this._finalText()
+  }
+  private async _finalText() {
+    return (await this.finalEvent).text
+  }
+
+  // Get the data from the end of the result stream, when it is ready.
+  get finalData(): Promise<KurtSchemaResultMaybe<T>> {
+    return this._finalData()
+  }
+  private async _finalData() {
+    return (await this.finalEvent).data
+  }
+
+  // Get each event in the stream (each yielded from this `AsyncGenerator`).
   async *[Symbol.asyncIterator]() {
-    for await (const event of this.gen) {
-      yield event
-      if ("finished" in event) break
+    // If some other caller has already started iterating on this stream,
+    // we can't let them consume from the same underlying generator, because the
+    // multiple watchers would disrupt each others view of the generated items.
+    //
+    // So as a workaround, we have a mechanism to "watch as an additional
+    // listener", where we return a new generator that will receive events
+    // second-hand from this generator, with this generator being the only
+    // one that listens to the
+    if (this.started)
+      for await (const event of this.watchAsAdditionalListener()) yield event
+
+    this.started = true
+    try {
+      for await (const event of this.gen) {
+        // Yield the event, capture it in our internal event history,
+        // and push it to any additional listeners who are waiting.
+        yield event
+        this.seenEvents.push(event)
+        for (const listener of this.additionalListeners) listener(event)
+
+        // If this is the final event, store it, resolve the final promise,
+        // and break out of the event-receiving loop.
+        //
+        // If we have a misbehaving underlying generator that has more events
+        // after the finish event, we'll be ignoring those.
+        if ("finished" in event) {
+          this.finalEventValue = event
+          this.finalEventResolve(event)
+          break
+        }
+      }
+    } catch (e) {
+      // If we catch an error, we need to reject the final promise and also
+      // notify any additional listeners, so that each of them can stop
+      // listening and throw the error to their outer caller.
+      this.finalEventReject(e)
+      for (const listener of this.additionalListeners)
+        listener({ uncaughtError: e })
+
+      // Finally we'll await on the promise we rejected above, to make sure
+      // that the error is thrown to the outer caller, and ensure that it
+      // doesn't "appear to be" an uncaught promise rejection.
+      await this.finalEventPromise
+    } finally {
+      // We need to make sure we mark the stream as finished, even in the
+      // case where the stream had an error before receiving the final event.
+      // This finished flag doesn't mark reception of a final event - it marks
+      // the fact that the stream won't receive any further events.
+      this.finished = true
+    }
+  }
+
+  private async *watchAsAdditionalListener() {
+    // First, catch up on any events we missed so far.
+    for (const event of this.seenEvents) yield event
+
+    // If the stream is already finished (or errored), we don't need to actually
+    // set up a listener. We can just join onto the final event promise,
+    // to make sure we throw the error from it if the promise was rejected.
+    if (this.finished) {
+      await this.finalEventPromise
+      return
+    }
+
+    // To make this generator work, we need to set up a replaceable promise
+    // that will receive the next event (or error) via the listener callback.
+    let nextEventResolve: (value: Promisable<KurtResultEvent<T>>) => void
+    let nextEventReject: (reason?: unknown) => void
+    let createNextEventPromise = () => {
+      return new Promise<KurtResultEvent<T>>((resolve, reject) => {
+        nextEventResolve = resolve
+        nextEventReject = reject
+      })
+    }
+    let nextEvent = createNextEventPromise()
+
+    // Set up an "additional listener" callback to receive events from the main
+    // listener (the first to start consuming from the underlying generator).
+    //
+    // Each time we receive an event we're going to resolve (or reject)
+    // the current promise, then we will replace the promise (and its
+    // associated resolve/reject functions), using closures.
+    const listener: _AdditionalListener<T> = (event) => {
+      if ("uncaughtError" in event) nextEventReject(event.uncaughtError)
+      else nextEventResolve(event)
+      nextEvent = createNextEventPromise()
+    }
+    this.additionalListeners.add(listener)
+
+    try {
+      // Now our generator is as simple as waiting on the next promise,
+      // over and over again, until we see the final event.
+      while (!this.finalEventValue) {
+        const event = await nextEvent
+        yield event
+        if ("finished" in event) break
+      }
+    } finally {
+      // Make sure to remove our listener at the end, even in the case of error.
+      this.additionalListeners.delete(listener)
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "lib": ["esnext"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "target": "ES2015"
+    "target": "ES2015",
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
This will be more convenient for callers who are not interested in the stream, and only want the final event or text/data from it.

This commit also adds a fair bit complexity to KurtResult, so that it will behave correctly if there are multiple concurrent "awaiters" using the `AsyncIterable` interface and/or the convenience `Promise` getters.

Tests are included to ensure that we get the correct behavior in many concurrent cases.