### PR TITLE
refactor: Simplify type params of KurtStream (and refactor surrounding to match)

### DIFF
--- a/src/Kurt.ts
+++ b/src/Kurt.ts
@@ -1,14 +1,18 @@
 import type { KurtStream } from "./KurtStream"
-import type { KurtSchema, KurtSchemaInner } from "./KurtSchema"
+import type {
+  KurtSchema,
+  KurtSchemaInner,
+  KurtSchemaResult,
+} from "./KurtSchema"
 
 export interface Kurt {
   generateNaturalLanguage(
     options: KurtGenerateNaturalLanguageOptions
   ): KurtStream
 
-  generateStructuredData<T extends KurtSchemaInner>(
-    options: KurtGenerateStructuredDataOptions<T>
-  ): KurtStream<T>
+  generateStructuredData<I extends KurtSchemaInner>(
+    options: KurtGenerateStructuredDataOptions<I>
+  ): KurtStream<KurtSchemaResult<I>>
 }
 
 export interface KurtMessage {
@@ -26,7 +30,7 @@ export interface KurtGenerateNaturalLanguageOptions {
   extraMessages?: KurtMessage[]
 }
 
-export type KurtGenerateStructuredDataOptions<T extends KurtSchemaInner> =
+export type KurtGenerateStructuredDataOptions<I extends KurtSchemaInner> =
   KurtGenerateNaturalLanguageOptions & {
-    schema: KurtSchema<T>
+    schema: KurtSchema<I>
   }

--- a/src/KurtSchema.ts
+++ b/src/KurtSchema.ts
@@ -1,11 +1,11 @@
 import type { ZodObject, ZodRawShape, infer as zodInfer } from "zod"
 
 export type KurtSchemaInner = ZodRawShape
-export type KurtSchema<T extends KurtSchemaInner> = ZodObject<T>
-export type KurtSchemaResult<T extends KurtSchemaInner> = zodInfer<ZodObject<T>>
+export type KurtSchema<I extends KurtSchemaInner> = ZodObject<I>
+export type KurtSchemaResult<I extends KurtSchemaInner> = zodInfer<ZodObject<I>>
 
 export type KurtSchemaInnerMaybe = KurtSchemaInner | undefined
-export type KurtSchemaMaybe<T extends KurtSchemaInnerMaybe> =
-  T extends KurtSchemaInner ? KurtSchema<T> : undefined
-export type KurtSchemaResultMaybe<T extends KurtSchemaInnerMaybe> =
-  T extends KurtSchemaInner ? KurtSchemaResult<T> : undefined
+export type KurtSchemaMaybe<I extends KurtSchemaInnerMaybe> =
+  I extends KurtSchemaInner ? KurtSchema<I> : undefined
+export type KurtSchemaResultMaybe<I extends KurtSchemaInnerMaybe> =
+  I extends KurtSchemaInner ? KurtSchemaResult<I> : undefined


### PR DESCRIPTION
Prior to this commit, the type argument of KurtStream needed to be the inner schema (i.e. something that `extends KurtSchemaMaybe`) and from this we derived what the result data type would be.

However, that was overly complicated, and nothing about the inner schema was actually being used within the class - only the derived result data type.

So, to simplify things, KurtStream's type argument is now the actual result data type itself, rather than the schema. This makes it easier for callers who want to use the KurtStream or KurtStreamEvent or KurtResult data types, as each of these now can take an easier-to-obtain type argument.

BREAKING CHANGE: Type argument of KurtStream has changed its meaning