### PR TITLE
feat: add generateWithOptionalTools to Kurt interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ const kurt: Kurt = new KurtVertexAI({
 
 ## Generate Natural Language Output
 
+The most basic use case for an LLM is to ask it to generate some text.
+
 ```ts
 const stream = kurt.generateNaturalLanguage({
   prompt: "Say hello!",
@@ -73,6 +75,12 @@ console.log(text)
 
 ## Generate Structured Data Output
 
+If we want an LLM to make decisions or perform tasks within a larger system, we often need it to format its response as structured data rather than natural language.
+
+Using the `zod` library as a convenient way to specify a JSON schema in TypeScript, we can force the LLM to generate structured data that conforms to the given schema.
+
+For best results, be sure to include descriptions of every field in the schema, as these will be used by the LLM as documentation to determine how best to fill the fields with data.
+
 ```ts
 import { z } from "zod"
 
@@ -96,4 +104,69 @@ for await (const event of stream) {
 const { data } = await stream.result
 console.log(data)
 // { say: "hello" }
+```
+
+## Generate With Optional Tools
+
+Sometimes we may want to ask the LLM to produce a natural language response, but with the option of using some tools (in a structured data format) as part of its self-directed process of fulfilling the prompt.
+
+This is a bit of a mixture of the above two cases - we are expecting the LLM to make zero or more tool calls, and then eventually produce a natural language response.
+
+As above, we can use the `zod` library to conveniently declare the JSON schema for the tools, given as a map of named tools.
+
+Again, for best results, we should include helpful descriptions of each tool schema, and each field within them, so that the LLM can make a more informed decision about how to use the tools.
+
+```ts
+import { z } from "zod"
+
+const prompt =
+  "What's 9876356 divided by 30487, rounded to the nearest integer?"
+
+const tools = {
+  subtract: z
+    .object({
+      minuend: z.number().describe("The number to subtract from"),
+      subtrahend: z.number().describe("The number to subtract by"),
+    })
+    .describe("Calculate a subtraction expression"),
+  divide: z
+    .object({
+      dividend: z.number().describe("The number to be divided"),
+      divisor: z.number().describe("The number to divide by"),
+    })
+    .describe("Calculate a division expression"),
+}
+
+// Run Kurt in a loop until it produces a natural language response,
+// or until we reach a maximum number of iterations.
+const extraMessages: KurtMessage[] = []
+const MAX_ITERATIONS = 3
+for (let i = 0; i < MAX_ITERATIONS; i++) {
+  const { text, data } = await kurt.generateWithOptionalTools({
+    prompt,
+    tools,
+  }).result
+
+  // If there is data in the result, it means the LLM made a tool call.
+  if (data) {
+    const { name, args } = data
+    let result = {}
+    if (name === "divide") {
+      result = { quotient: args.dividend / args.divisor }
+    } else if (name === "subtract") {
+      result = { difference: args.minuend - args.subtrahend }
+    }
+    const toolCall = { name, args, result }
+    extraMessages.push({ role: "model", toolCall })
+    console.log(toolCall)
+    // {
+    //   name: "divide",
+    //   args: { dividend: 9876356, divisor: 30487 },
+    //   result: { quotient: 323.95302915996984 },
+    // }
+  } else {
+    console.log(text) // "The answer, rounded to the nearest integer, is 324."
+    break
+  }
+}
 ```

--- a/packages/kurt-open-ai/spec/KurtOpenAI.spec.ts
+++ b/packages/kurt-open-ai/spec/KurtOpenAI.spec.ts
@@ -202,4 +202,368 @@ describe("KurtOpenAI", () => {
       },
     ])
   })
+
+  test("generateWithOptionalTools (with tool call)", async () => {
+    const req = {
+      prompt:
+        "What's 9876356 divided by 30487, rounded to the nearest integer?",
+      tools: {
+        subtract: z
+          .object({
+            minuend: z.number().describe("The number to subtract from"),
+            subtrahend: z.number().describe("The number to subtract by"),
+          })
+          .describe("Calculate a subtraction"),
+        divide: z
+          .object({
+            dividend: z.number().describe("The number to be divided"),
+            divisor: z.number().describe("The number to divide by"),
+          })
+          .describe("Calculate a division"),
+      },
+    }
+
+    const kurt = setupExpectingCall(
+      {
+        stream: true,
+        model: "gpt-3.5-turbo-0125",
+        messages: [
+          {
+            role: "user",
+            content:
+              "What's 9876356 divided by 30487, rounded to the nearest integer?",
+          },
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "subtract",
+              description: "Calculate a subtraction",
+              parameters: {
+                $schema: "http://json-schema.org/draft-07/schema#",
+                type: "object",
+                description: "Calculate a subtraction",
+                properties: {
+                  minuend: {
+                    type: "number",
+                    description: "The number to subtract from",
+                  },
+                  subtrahend: {
+                    type: "number",
+                    description: "The number to subtract by",
+                  },
+                },
+                required: ["minuend", "subtrahend"],
+                additionalProperties: false,
+              },
+            },
+          },
+          {
+            type: "function",
+            function: {
+              name: "divide",
+              description: "Calculate a division",
+              parameters: {
+                $schema: "http://json-schema.org/draft-07/schema#",
+                type: "object",
+                description: "Calculate a division",
+                properties: {
+                  dividend: {
+                    type: "number",
+                    description: "The number to be divided",
+                  },
+                  divisor: {
+                    type: "number",
+                    description: "The number to divide by",
+                  },
+                },
+                required: ["dividend", "divisor"],
+                additionalProperties: false,
+              },
+            },
+          },
+        ],
+      },
+      [
+        {
+          delta: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                index: 0,
+                id: "call_j4y9gDgKXEqFzUbmjroAS6xf",
+                type: "function",
+                function: {
+                  name: "divide",
+                  arguments: "",
+                },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: '{"' } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "div" } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "idend" } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: '":' } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "987" } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "635" } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "6" } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: ',"' } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "div" } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "isor" } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: '":' } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "304" } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "87" } }],
+          },
+          finish_reason: null,
+        },
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: "}" } }],
+          },
+          finish_reason: null,
+        },
+        { delta: {}, finish_reason: "stop" },
+      ]
+    )
+
+    expect(await arrayFromAsync(kurt.generateWithOptionalTools(req))).toEqual([
+      { chunk: '{"' },
+      { chunk: "div" },
+      { chunk: "idend" },
+      { chunk: '":' },
+      { chunk: "987" },
+      { chunk: "635" },
+      { chunk: "6" },
+      { chunk: ',"' },
+      { chunk: "div" },
+      { chunk: "isor" },
+      { chunk: '":' },
+      { chunk: "304" },
+      { chunk: "87" },
+      { chunk: "}" },
+      {
+        finished: true,
+        text: '{"dividend":9876356,"divisor":30487}',
+        data: { name: "divide", args: { dividend: 9876356, divisor: 30487 } },
+      },
+    ])
+  })
+
+  test("generateWithOptionalTools (after tool call)", async () => {
+    const req = {
+      prompt:
+        "What's 9876356 divided by 30487, rounded to the nearest integer?",
+      tools: {
+        subtract: z
+          .object({
+            minuend: z.number().describe("The number to subtract from"),
+            subtrahend: z.number().describe("The number to subtract by"),
+          })
+          .describe("Calculate a subtraction"),
+        divide: z
+          .object({
+            dividend: z.number().describe("The number to be divided"),
+            divisor: z.number().describe("The number to divide by"),
+          })
+          .describe("Calculate a division"),
+      },
+      extraMessages: [
+        {
+          role: "model" as const,
+          toolCall: {
+            name: "divide",
+            args: { dividend: 9876356, divisor: 30487 },
+            result: { quotient: 323.95302915996984 },
+          },
+        },
+      ],
+    }
+
+    const kurt = setupExpectingCall(
+      {
+        stream: true,
+        model: "gpt-3.5-turbo-0125",
+        messages: [
+          {
+            role: "user",
+            content:
+              "What's 9876356 divided by 30487, rounded to the nearest integer?",
+          },
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_0",
+                type: "function",
+                function: {
+                  name: "divide",
+                  arguments: '{"dividend":9876356,"divisor":30487}',
+                },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "call_0",
+            content: '{"quotient":323.95302915996984}',
+          },
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "subtract",
+              description: "Calculate a subtraction",
+              parameters: {
+                $schema: "http://json-schema.org/draft-07/schema#",
+                type: "object",
+                description: "Calculate a subtraction",
+                properties: {
+                  minuend: {
+                    type: "number",
+                    description: "The number to subtract from",
+                  },
+                  subtrahend: {
+                    type: "number",
+                    description: "The number to subtract by",
+                  },
+                },
+                required: ["minuend", "subtrahend"],
+                additionalProperties: false,
+              },
+            },
+          },
+          {
+            type: "function",
+            function: {
+              name: "divide",
+              description: "Calculate a division",
+              parameters: {
+                $schema: "http://json-schema.org/draft-07/schema#",
+                type: "object",
+                description: "Calculate a division",
+                properties: {
+                  dividend: {
+                    type: "number",
+                    description: "The number to be divided",
+                  },
+                  divisor: {
+                    type: "number",
+                    description: "The number to divide by",
+                  },
+                },
+                required: ["dividend", "divisor"],
+                additionalProperties: false,
+              },
+            },
+          },
+        ],
+      },
+      [
+        {
+          delta: { role: "assistant", content: "" },
+          finish_reason: null,
+        },
+        { delta: { content: "Rounded" }, finish_reason: null },
+        { delta: { content: " to" }, finish_reason: null },
+        { delta: { content: " the" }, finish_reason: null },
+        { delta: { content: " nearest" }, finish_reason: null },
+        { delta: { content: " integer" }, finish_reason: null },
+        { delta: { content: "," }, finish_reason: null },
+        { delta: { content: " the" }, finish_reason: null },
+        { delta: { content: " result" }, finish_reason: null },
+        { delta: { content: " is" }, finish_reason: null },
+        { delta: { content: " " }, finish_reason: null },
+        { delta: { content: "324" }, finish_reason: null },
+        { delta: { content: "." }, finish_reason: null },
+        { delta: { content: "" }, finish_reason: "stop" },
+      ]
+    )
+
+    expect(await arrayFromAsync(kurt.generateWithOptionalTools(req))).toEqual([
+      { chunk: "Rounded" },
+      { chunk: " to" },
+      { chunk: " the" },
+      { chunk: " nearest" },
+      { chunk: " integer" },
+      { chunk: "," },
+      { chunk: " the" },
+      { chunk: " result" },
+      { chunk: " is" },
+      { chunk: " " },
+      { chunk: "324" },
+      { chunk: "." },
+      {
+        finished: true,
+        text: "Rounded to the nearest integer, the result is 324.",
+        data: undefined,
+      },
+    ])
+  })
 })

--- a/packages/kurt/src/Kurt.ts
+++ b/packages/kurt/src/Kurt.ts
@@ -1,7 +1,11 @@
+import type { RequireExactlyOne } from "type-fest"
 import type { KurtStream } from "./KurtStream"
 import type {
   KurtSchema,
   KurtSchemaInner,
+  KurtSchemaInnerMap,
+  KurtSchemaMap,
+  KurtSchemaMapSingleResult,
   KurtSchemaResult,
 } from "./KurtSchema"
 
@@ -13,12 +17,22 @@ export interface Kurt {
   generateStructuredData<I extends KurtSchemaInner>(
     options: KurtGenerateStructuredDataOptions<I>
   ): KurtStream<KurtSchemaResult<I>>
+
+  generateWithOptionalTools<I extends KurtSchemaInnerMap>(
+    options: KurtGenerateWithOptionalToolsOptions<I>
+  ): KurtStream<KurtSchemaMapSingleResult<I> | undefined>
 }
 
-export interface KurtMessage {
+export type KurtMessage = {
   role: "user" | "model" | "system"
+} & RequireExactlyOne<{
   text: string
-}
+  toolCall: {
+    name: string
+    args: object
+    result: object
+  }
+}>
 
 export interface KurtCreateOptions {
   systemPrompt?: string
@@ -33,4 +47,9 @@ export interface KurtGenerateNaturalLanguageOptions {
 export type KurtGenerateStructuredDataOptions<I extends KurtSchemaInner> =
   KurtGenerateNaturalLanguageOptions & {
     schema: KurtSchema<I>
+  }
+
+export type KurtGenerateWithOptionalToolsOptions<I extends KurtSchemaInnerMap> =
+  KurtGenerateNaturalLanguageOptions & {
+    tools: KurtSchemaMap<I>
   }

--- a/packages/kurt/src/KurtSchema.ts
+++ b/packages/kurt/src/KurtSchema.ts
@@ -9,3 +9,14 @@ export type KurtSchemaMaybe<I extends KurtSchemaInnerMaybe> =
   I extends KurtSchemaInner ? KurtSchema<I> : undefined
 export type KurtSchemaResultMaybe<I extends KurtSchemaInnerMaybe> =
   I extends KurtSchemaInner ? KurtSchemaResult<I> : undefined
+
+export type KurtSchemaInnerMap = { [key: string]: KurtSchemaInner }
+export type KurtSchemaMap<I extends KurtSchemaInnerMap> = {
+  [key in keyof I]: KurtSchema<I[key]>
+}
+export type KurtSchemaMapSingleResult<I extends KurtSchemaInnerMap> = {
+  [K in keyof I]: {
+    name: K
+    args: KurtSchemaResult<I[K]>
+  }
+}[keyof I]


### PR DESCRIPTION
Sometimes we may want to ask the LLM to produce a
natural language response, but with the option of
using some tools (in a structured data format) as
part of its self-directed process of fulfilling the prompt.

This is a bit of a mixture of the prior two methods in the interface - we are expecting the LLM to make zero or more tool calls, and then eventually produce a natural language response.

See the README.md example and the spec examples to get a feel for how this works.