### PR TITLE
refactor: change Kurt from an interface to an abstract class

### DIFF
--- a/packages/kurt-open-ai/src/KurtOpenAI.ts
+++ b/packages/kurt-open-ai/src/KurtOpenAI.ts
@@ -1,7 +1,6 @@
 import { zodToJsonSchema } from "zod-to-json-schema"
-import { KurtStream } from "@formula-monks/kurt"
+import { Kurt, KurtStream } from "@formula-monks/kurt"
 import type {
-  Kurt,
   KurtCreateOptions,
   KurtGenerateNaturalLanguageOptions,
   KurtGenerateStructuredDataOptions,
@@ -37,8 +36,10 @@ export type KurtOpenAICreateOptions = KurtCreateOptions & {
   openAI: OpenAI
 }
 
-export class KurtOpenAI implements Kurt {
-  constructor(private options: KurtOpenAICreateOptions) {}
+export class KurtOpenAI extends Kurt {
+  constructor(private options: KurtOpenAICreateOptions) {
+    super()
+  }
 
   generateNaturalLanguage(
     options: KurtGenerateNaturalLanguageOptions

--- a/packages/kurt-vertex-ai/src/KurtVertexAI.ts
+++ b/packages/kurt-vertex-ai/src/KurtVertexAI.ts
@@ -1,9 +1,8 @@
 import "./VertexAI.patch.generateContentStream" // monkey-patches VertexAI GenerativeModel.prototype.generateContentStream
 
 import zodToJsonSchema from "zod-to-json-schema"
-import { KurtStream } from "@formula-monks/kurt"
+import { Kurt, KurtStream } from "@formula-monks/kurt"
 import type {
-  Kurt,
   KurtCreateOptions,
   KurtGenerateNaturalLanguageOptions,
   KurtGenerateStructuredDataOptions,
@@ -37,8 +36,10 @@ export type KurtVertexAICreateOptions = KurtCreateOptions & {
   vertexAI: VertexAI
 }
 
-export class KurtVertexAI implements Kurt {
-  constructor(private options: KurtVertexAICreateOptions) {}
+export class KurtVertexAI extends Kurt {
+  constructor(private options: KurtVertexAICreateOptions) {
+    super()
+  }
 
   generateNaturalLanguage(
     options: KurtGenerateNaturalLanguageOptions

--- a/packages/kurt/src/Kurt.ts
+++ b/packages/kurt/src/Kurt.ts
@@ -9,16 +9,16 @@ import type {
   KurtSchemaResult,
 } from "./KurtSchema"
 
-export interface Kurt {
-  generateNaturalLanguage(
+export abstract class Kurt {
+  abstract generateNaturalLanguage(
     options: KurtGenerateNaturalLanguageOptions
   ): KurtStream
 
-  generateStructuredData<I extends KurtSchemaInner>(
+  abstract generateStructuredData<I extends KurtSchemaInner>(
     options: KurtGenerateStructuredDataOptions<I>
   ): KurtStream<KurtSchemaResult<I>>
 
-  generateWithOptionalTools<I extends KurtSchemaInnerMap>(
+  abstract generateWithOptionalTools<I extends KurtSchemaInnerMap>(
     options: KurtGenerateWithOptionalToolsOptions<I>
   ): KurtStream<KurtSchemaMapSingleResult<I> | undefined>
 }


### PR DESCRIPTION
This will enable Kurt to provide some convenience methods in a common place (implemented as a composite of the abstract methods that each concrete class must implement.

An example of the kind of convenience method I'm talking about is described in [this comment](https://github.com/FormulaMonks/kurt/pull/12#issuecomment-2099251542).

Overall, this is a breaking change so I want to introduce it before the impending public release.

BREAKING CHANGE: Kurt is now an abstract class.