### PR TITLE
refactor: make Kurt a concrete class that accepts an LLM-specific adapter object

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,21 @@ Unlike Langchain, Kurt won't bother trying to support structured output with LLM
 ## Create Kurt with your LLM of choice
 
 ```ts
-const kurt: Kurt = new KurtOpenAI({
-  openAI: new OpenAI(),
-  model: "gpt-3.5-turbo-0125",
-})
+const kurt = new Kurt(
+  new KurtOpenAI({
+    openAI: new OpenAI(),
+    model: "gpt-3.5-turbo-0125",
+  })
+)
 ```
 
 ```ts
-const kurt: Kurt = new KurtVertexAI({
-  vertexAI: new VertexAI({ project: "my-project", location: "us-central1" }),
-  model: "gemini-1.0-pro",
-})
+const kurt = new Kurt(
+  new KurtVertexAI({
+    vertexAI: new VertexAI({ project: "my-project", location: "us-central1" }),
+    model: "gemini-1.0-pro",
+  })
+)
 ```
 
 ## Generate Natural Language Output

--- a/packages/kurt-open-ai/spec/KurtOpenAI.spec.ts
+++ b/packages/kurt-open-ai/spec/KurtOpenAI.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@jest/globals"
 import { OpenAI as RealOpenAI } from "openai"
 import { z } from "zod"
+import { Kurt } from "@formula-monks/kurt"
 import { KurtOpenAI } from "../src/KurtOpenAI"
 import type {
   OpenAI,
@@ -34,10 +35,7 @@ function setupExpectingCall(
         },
       } as unknown as OpenAI)
 
-  return new KurtOpenAI({
-    openAI,
-    model: "gpt-3.5-turbo-0125",
-  })
+  return new Kurt(new KurtOpenAI({ openAI, model: "gpt-3.5-turbo-0125" }))
 }
 
 async function arrayFromAsync<T>(iter: AsyncIterable<T>): Promise<T[]> {
@@ -459,7 +457,7 @@ describe("KurtOpenAI", () => {
             role: "assistant",
             tool_calls: [
               {
-                id: "call_0",
+                id: "call_1",
                 type: "function",
                 function: {
                   name: "divide",
@@ -470,10 +468,11 @@ describe("KurtOpenAI", () => {
           },
           {
             role: "tool",
-            tool_call_id: "call_0",
+            tool_call_id: "call_1",
             content: '{"quotient":323.95302915996984}',
           },
         ],
+        tool_choice: undefined,
         tools: [
           {
             type: "function",

--- a/packages/kurt-open-ai/src/OpenAI.types.ts
+++ b/packages/kurt-open-ai/src/OpenAI.types.ts
@@ -2,6 +2,8 @@ import type { OpenAI as RealOpenAI } from "openai"
 import type {
   ChatCompletionCreateParamsStreaming,
   ChatCompletionMessageParam,
+  FunctionParameters,
+  ChatCompletionTool,
   ChatCompletionChunk,
 } from "openai/resources/index"
 
@@ -9,6 +11,8 @@ export type OpenAI = RealOpenAI
 
 export type OpenAIRequest = ChatCompletionCreateParamsStreaming
 export type OpenAIMessage = ChatCompletionMessageParam
+export type OpenAISchema = FunctionParameters
+export type OpenAITool = ChatCompletionTool
 export type OpenAIResponse = Promise<AsyncIterable<OpenAIResponseChunk>>
 export type OpenAIResponseChunk = {
   choices: Pick<

--- a/packages/kurt-vertex-ai/spec/KurtVertexAI.spec.ts
+++ b/packages/kurt-vertex-ai/spec/KurtVertexAI.spec.ts
@@ -10,6 +10,7 @@ import type {
   VertexAIResponseChunkCandidate,
   VertexAISchema,
 } from "../src/VertexAI.types"
+import { Kurt } from "@formula-monks/kurt"
 
 const USE_REAL_API = false // set to true to validate against actual VertexAI
 
@@ -48,10 +49,7 @@ function setupExpectingCall(
         },
       } as unknown as VertexAI)
 
-  return new KurtVertexAI({
-    vertexAI,
-    model: "gemini-1.0-pro",
-  })
+  return new Kurt(new KurtVertexAI({ vertexAI, model: "gemini-1.0-pro" }))
 }
 
 async function arrayFromAsync<T>(iter: AsyncIterable<T>): Promise<T[]> {
@@ -108,7 +106,12 @@ describe("KurtVertexAI", () => {
     const kurt = setupExpectingCall(
       {
         contents: [{ role: "user", parts: [{ text: req.prompt }] }],
-        tool_config: { function_calling_config: { mode: "ANY" } },
+        tool_config: {
+          function_calling_config: {
+            mode: "ANY",
+            allowed_function_names: ["structured_data"],
+          },
+        },
         tools: [
           {
             functionDeclarations: [
@@ -172,7 +175,12 @@ describe("KurtVertexAI", () => {
     const kurt = setupExpectingCall(
       {
         contents: [{ role: "user", parts: [{ text: req.prompt }] }],
-        tool_config: { function_calling_config: { mode: "ANY" } },
+        tool_config: {
+          function_calling_config: {
+            mode: "ANY",
+            allowed_function_names: ["structured_data"],
+          },
+        },
         tools: [
           {
             functionDeclarations: [
@@ -240,7 +248,12 @@ describe("KurtVertexAI", () => {
     const kurt = setupExpectingCall(
       {
         contents: [{ role: "user", parts: [{ text: req.prompt }] }],
-        tool_config: { function_calling_config: { mode: "ANY" } },
+        tool_config: {
+          function_calling_config: {
+            mode: "ANY",
+            allowed_function_names: ["structured_data"],
+          },
+        },
         tools: [
           {
             functionDeclarations: [

--- a/packages/kurt-vertex-ai/src/VertexAI.types.ts
+++ b/packages/kurt-vertex-ai/src/VertexAI.types.ts
@@ -4,6 +4,7 @@ import type {
   Content,
   GenerateContentRequest,
   GenerateContentCandidate,
+  FunctionDeclaration,
   FunctionDeclarationSchema,
 } from "@google-cloud/vertexai"
 
@@ -24,6 +25,7 @@ export type VertexAIRequest = GenerateContentRequest & {
   }
 }
 export type VertexAISchema = FunctionDeclarationSchema
+export type VertexAITool = FunctionDeclaration
 export type VertexAIResponse = Promise<{
   stream: AsyncGenerator<VertexAIResponseChunk>
 }>

--- a/packages/kurt/src/KurtAdapter.ts
+++ b/packages/kurt/src/KurtAdapter.ts
@@ -1,0 +1,67 @@
+import type { KurtMessage } from "./Kurt"
+import type { KurtStreamEvent } from "./KurtStream"
+import type {
+  KurtSchema,
+  KurtSchemaInner,
+  KurtSchemaInnerMap,
+  KurtSchemaMap,
+  KurtSchemaMapSingleResult,
+  KurtSchemaResult,
+} from "./KurtSchema"
+
+type V1TypeParams = {
+  rawMessage: object
+  rawSchema: object
+  rawTool: object
+  rawEvent: object
+}
+
+// In future, other versions will be added, to allow evolving the adapter
+// interface without breaking changes in the linkage between the central
+// Kurt library and the adapter sub-libraries.
+export type KurtAdapter = KurtAdapterV1<{
+  // biome-ignore lint/suspicious/noExplicitAny: we use any here to ignore the adapter implementation details
+  rawMessage: any
+  // biome-ignore lint/suspicious/noExplicitAny: we use any here to ignore the adapter implementation details
+  rawSchema: any
+  // biome-ignore lint/suspicious/noExplicitAny: we use any here to ignore the adapter implementation details
+  rawTool: any
+  // biome-ignore lint/suspicious/noExplicitAny: we use any here to ignore the adapter implementation details
+  rawEvent: any
+}>
+
+export interface KurtAdapterV1<A extends V1TypeParams = V1TypeParams> {
+  kurtAdapterVersion: "v1"
+
+  transformToRawMessages(messages: KurtMessage[]): A["rawMessage"][]
+
+  transformToRawSchema<I extends KurtSchemaInner>(
+    schema: KurtSchema<I>
+  ): A["rawSchema"]
+
+  transformToRawTool(tool: {
+    name: string
+    description: string
+    parameters: A["rawSchema"]
+  }): A["rawTool"]
+
+  generateRawEvents(options: {
+    messages: A["rawMessage"][]
+    tools: { [key: string]: A["rawTool"] }
+    forceTool?: string
+  }): AsyncIterable<A["rawEvent"]>
+
+  transformNaturalLanguageFromRawEvents(
+    rawEvents: AsyncIterable<A["rawEvent"]>
+  ): AsyncIterable<KurtStreamEvent<undefined>>
+
+  transformStructuredDataFromRawEvents<I extends KurtSchemaInner>(
+    schema: KurtSchema<I>,
+    rawEvents: AsyncIterable<A["rawEvent"]>
+  ): AsyncIterable<KurtStreamEvent<KurtSchemaResult<I>>>
+
+  transformWithOptionalToolsFromRawEvents<I extends KurtSchemaInnerMap>(
+    tools: KurtSchemaMap<I>,
+    rawEvents: AsyncIterable<A["rawEvent"]>
+  ): AsyncIterable<KurtStreamEvent<KurtSchemaMapSingleResult<I> | undefined>>
+}

--- a/packages/kurt/src/KurtStream.ts
+++ b/packages/kurt/src/KurtStream.ts
@@ -85,7 +85,7 @@ export class KurtStream<D = undefined>
    * Create a new result stream, from the given underlying stream generator.
    * @param gen - A well-formatted stream of events from the underlying LLM.
    */
-  constructor(private gen: AsyncGenerator<KurtStreamEvent<D>>) {}
+  constructor(private gen: AsyncIterable<KurtStreamEvent<D>>) {}
 
   /**
    * Get the final event from the end of the result stream, when it is ready.

--- a/packages/kurt/src/index.ts
+++ b/packages/kurt/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./Kurt"
+export * from "./KurtAdapter"
 export * from "./KurtStream"
 export * from "./KurtSchema"


### PR DESCRIPTION
Based on some discussion in Slack, we want to move away from the abstract class pattern for Kurt, and also try to centralize some of the common elements across different sub-libraries.

This commit moves us in that direction by using an adapter object with functions that get composed by the central Kurt class.

Note that we want to be able to evolve the adapter interface over time without hard breaking changes, so I have set this up in a KurtAdapterV1 interface. A map of type parameters is used to ensure that the intermediate data structures can have strong typing.