### PR TITLE
build: add missing declarations enablement to kurt-open-ai tsconfig

### DIFF
--- a/packages/kurt-open-ai/tsconfig.json
+++ b/packages/kurt-open-ai/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
+    "declaration": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "downlevelIteration": true,


### PR DESCRIPTION
This was missing, causing declarations not to built for the public package. This commit fixes that by enabling the setting.

The other packages already had this setting correct.