### PR TITLE
ci: use an environment-locked secret for NPM_TOKEN in CI publish step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   ci:
+    environment: ${{ github.ref == 'refs/heads/main' && 'publish' || 'test' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # to publish releases


### PR DESCRIPTION
This constitutes an important security protection.

Prior to this commit, a malicious actor could craft a malicious PR to exfitrate our `NPM_TOKEN` from GitHub Actions, *even if we don't merge the PR*, because the secret was available whenever GitHub Actions was running on this repo.

There is some protection we already had in place, in that first-time contributors would need to have approval from us before GitHub Actions would run CI code from their forks. However, this defense can still be breached with a bit of patience from the attacker - the malicious first-contributor only needs to issue one innocuous PR (e.g. a simple documentation improvement that is likely to be approved and merged) before then filing the malicious PR that exfiltrates the secret before we'd have any chance to react or prevent it.

With this change, our CI workflow now sets the environment based on which branch we're running on, such that we'll only use the `publish` environment when running on the `main` branch, and use the `test` environment at all other times. Note also that the GitHub environment settings have been configured to make the `publish` environment only accessible on the `main` branch.

Once this PR is merged, we can remove the repository-level secret in favor of only an enviroment-level secret, such that the `NPM_TOKEN` is only available on the `main` branch, and we're in a better position to protect ourselves from malicious PRs (i.e. we'd actually have to merge the malicious PR before it could have access to exfiltrate the secret, and hopefully we'd be keen enough to recognize the maliciousness during review).