### PR TITLE
fix: make the adapters depend on non-workspace Kurt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,9 @@
 {
+  "pnpm": {
+    "overrides": {
+      "@formula-monks/kurt": "workspace:^"
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.7.3",
     "@commitlint/cli": "^19.3.0",

--- a/packages/kurt-open-ai/package.json
+++ b/packages/kurt-open-ai/package.json
@@ -20,7 +20,7 @@
     "extends": "semantic-release-monorepo"
   },
   "dependencies": {
-    "@formula-monks/kurt": "workspace:^",
+    "@formula-monks/kurt": "^1.0.0",
     "openai": "^4.40.0",
     "zod": "^3.23.5",
     "zod-to-json-schema": "^3.23.0"

--- a/packages/kurt-vertex-ai/package.json
+++ b/packages/kurt-vertex-ai/package.json
@@ -20,7 +20,7 @@
     "extends": "semantic-release-monorepo"
   },
   "dependencies": {
-    "@formula-monks/kurt": "workspace:^",
+    "@formula-monks/kurt": "^1.0.0",
     "@google-cloud/vertexai": "1.1.0",
     "zod": "^3.23.5",
     "zod-to-json-schema": "^3.23.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@formula-monks/kurt': workspace:^
+
 importers:
 
   .:


### PR DESCRIPTION
Prior to this commit, the adapter libraries were depending on a workspace version of Kurt. This is unfit for publishing, because downstream users of the libraries won't have Kurt in their workspace.

We need to depend on fixed versions of Kurt and then use pnpm overrides to make it use the workspace version of Kurt in local development.

This commit does that fix.