### PR TITLE
ci: run tests also without any pnpm overrides

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,19 @@ jobs:
       - uses: actions/setup-node@v2.5.1
         with: { node-version: 20.x }
       - run: npm install -g pnpm@9
+
+      # Main tests.
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test
       - run: pnpm run build
+
+      # Validate that the tests pass without the pnpm overrides that alter
+      # the intra-monorepo dependencies for local development.
+      - run: cat package.json | jq 'del(.pnpm.overrides)' | tee package.json
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm run test
+
+      # Finally, release (actual publishing only happens on the main branch).
       - run: pnpm run release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
For packages that depend on other packages in the monorepo, we are explicitly tracking by hand the minimum supported version of the intra-monorepo dependency, in the package.json `dependencies` list, and then for local development we are overriding that with pnpm overrides to allow experimentation across packages without publishing.

Tracking the minimum version explicitly (as opposed to always using the latest version as `pnpm publish` does) has the benefit that the user is not forced to update the common dependency unless it is absolutely necessary. This may help prevent some forms of "dependency hell" for users.

However, it has the downside that we might forget to update the version in the dependency list in some cases, and risk publishing a broken package as a result.

This PR prevents that case in CI, by removing any pnpm local workspace overrides before doing another `install` and `test`. This secondary `install` and `test` will download the "real" published versions of the dependencies from public NPM, and use those, just as a library user would, and run our tests with that environment. This has the benefits of:

- validating that we have chosen the working dependency version numbers (or letting us know that they need to be updated before merging the PR)
- validating that the published versions we depend on are actually working (or letting us know of some issue in our build/publish process)
- preventing merging a PR that includes any breaking changes, at least for the part of the dependency surface that is used and tested in a dependent library

We do have the caveat to note of:

- Any change that introduces a new feature in a dependency library and makes use of it in dependent libraries must be handled in two separate steps: first a PR to add the feature, then a separate PR that makes use of the feature in downstream libraries.

This is a tolerable downside, and could also be considered as enforcing a clean practice of developing these libraries in a way that is independent, despite sharing a repo.