### PR TITLE
feat: add `KurtSamplingOptions`, for tweaking output sampling details

### DIFF
--- a/packages/kurt/spec/FakeAdapterV1.ts
+++ b/packages/kurt/spec/FakeAdapterV1.ts
@@ -1,0 +1,98 @@
+import type { KurtSamplingOptions, KurtMessage } from "../src/Kurt"
+import type { KurtAdapterV1 } from "../src/KurtAdapter"
+import type { KurtStreamEvent } from "../src/KurtStream"
+import type {
+  KurtSchema,
+  KurtSchemaInner,
+  KurtSchemaInnerMap,
+  KurtSchemaMap,
+  KurtSchemaMapSingleResult,
+  KurtSchemaResult,
+} from "../src/KurtSchema"
+
+export type FakeMessage = { fake: KurtMessage }
+export type FakeSchema = { fake: object }
+export type FakeTool = {
+  fake: { name: string; description: string; parameters: FakeSchema }
+}
+export type FakeEvent = { fake: KurtStreamEvent<unknown> }
+export class FakeAdapterV1
+  implements
+    KurtAdapterV1<{
+      rawMessage: FakeMessage
+      rawSchema: FakeSchema
+      rawTool: FakeTool
+      rawEvent: FakeEvent
+    }>
+{
+  kurtAdapterVersion = "v1" as const
+
+  // Hook-in points for testing.
+  lastGenerateRawEventsCall?: Parameters<FakeAdapterV1["generateRawEvents"]>[0]
+  nextEmitKurtStreamEvents: KurtStreamEvent<unknown>[] = []
+
+  transformToRawMessages(messages: KurtMessage[]) {
+    return messages.map((message) => ({ fake: message }))
+  }
+
+  transformToRawSchema<I extends KurtSchemaInner>(schema: KurtSchema<I>) {
+    return { fake: schema }
+  }
+
+  transformToRawTool(tool: {
+    name: string
+    description: string
+    parameters: { fake: object }
+  }) {
+    return { fake: tool }
+  }
+
+  generateRawEvents(options: {
+    messages: { fake: KurtMessage }[]
+    sampling: KurtSamplingOptions
+    tools: {
+      [key: string]: ReturnType<FakeAdapterV1["transformToRawTool"]>
+    }
+    forceTool?: string
+  }) {
+    this.lastGenerateRawEventsCall = options
+    const events = this.nextEmitKurtStreamEvents
+    this.nextEmitKurtStreamEvents = []
+
+    async function* gen() {
+      for (const event of events) {
+        yield { fake: event }
+      }
+    }
+
+    return gen()
+  }
+
+  async *transformNaturalLanguageFromRawEvents(
+    rawEvents: AsyncIterable<FakeEvent>
+  ) {
+    for await (const rawEvent of rawEvents) {
+      yield rawEvent.fake as KurtStreamEvent<undefined>
+    }
+  }
+
+  async *transformStructuredDataFromRawEvents<I extends KurtSchemaInner>(
+    schema: KurtSchema<I>,
+    rawEvents: AsyncIterable<FakeEvent>
+  ) {
+    for await (const rawEvent of rawEvents) {
+      yield rawEvent.fake as KurtStreamEvent<KurtSchemaResult<I>>
+    }
+  }
+
+  async *transformWithOptionalToolsFromRawEvents<I extends KurtSchemaInnerMap>(
+    tools: KurtSchemaMap<I>,
+    rawEvents: AsyncIterable<FakeEvent>
+  ) {
+    for await (const rawEvent of rawEvents) {
+      yield rawEvent.fake as KurtStreamEvent<
+        KurtSchemaMapSingleResult<I> | undefined
+      >
+    }
+  }
+}

--- a/packages/kurt/spec/Kurt.spec.ts
+++ b/packages/kurt/spec/Kurt.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "@jest/globals"
+import { FakeAdapterV1 } from "./FakeAdapterV1"
+import {
+  Kurt,
+  type KurtCreateOptions,
+  type KurtSamplingOptions,
+  KurtSamplingOptionsDefault,
+} from "../src/Kurt"
+
+function createV1(options: KurtCreateOptions = {}) {
+  const adapter = new FakeAdapterV1()
+  const kurt = new Kurt(adapter, options)
+  return { adapter, kurt }
+}
+
+describe("Kurt", () => {
+  describe("sampling options", () => {
+    test("using entirely default values by default", async () => {
+      const { adapter, kurt } = createV1()
+
+      kurt.generateNaturalLanguage({ prompt: "Hello!" })
+
+      expect(adapter.lastGenerateRawEventsCall?.sampling).toEqual(
+        KurtSamplingOptionsDefault
+      )
+    })
+
+    test("using full overrides on creation", async () => {
+      const sampling: Required<KurtSamplingOptions> = {
+        maxOutputTokens: 1024,
+        temperature: 0.1,
+        topP: 0.5,
+      }
+      const { adapter, kurt } = createV1({ sampling })
+
+      kurt.generateNaturalLanguage({ prompt: "Hello!" })
+
+      expect(adapter.lastGenerateRawEventsCall?.sampling).toEqual(sampling)
+    })
+
+    test("using full overrides on generate call", async () => {
+      const { adapter, kurt } = createV1()
+
+      const sampling: Required<KurtSamplingOptions> = {
+        maxOutputTokens: 1024,
+        temperature: 0.1,
+        topP: 0.5,
+      }
+      kurt.generateNaturalLanguage({ prompt: "Hello!", sampling })
+
+      expect(adapter.lastGenerateRawEventsCall?.sampling).toEqual(sampling)
+    })
+
+    test("using partial overrides at each layer", async () => {
+      const { adapter, kurt } = createV1({
+        sampling: {
+          maxOutputTokens: 999, // will be shadowed by the generate call value
+          temperature: 0.1, // will not be shadowed
+        },
+      })
+
+      kurt.generateNaturalLanguage({
+        prompt: "Hello!",
+        sampling: { maxOutputTokens: 1024 },
+      })
+
+      expect(adapter.lastGenerateRawEventsCall?.sampling).toEqual({
+        ...KurtSamplingOptionsDefault,
+        temperature: 0.1,
+        maxOutputTokens: 1024,
+      })
+    })
+
+    test("complains when values violate certain bounds", () => {
+      const { kurt } = createV1()
+
+      expect(() =>
+        kurt.generateNaturalLanguage({
+          prompt: "Hello!",
+          sampling: { maxOutputTokens: 0 },
+        })
+      ).toThrow("maxOutputTokens must be at least 1 (got: 0)")
+
+      expect(() =>
+        kurt.generateNaturalLanguage({
+          prompt: "Hello!",
+          sampling: { temperature: -0.1 },
+        })
+      ).toThrow("temperature must be no less than 0 (got: -0.1)")
+
+      expect(() =>
+        kurt.generateNaturalLanguage({
+          prompt: "Hello!",
+          sampling: { topP: -0.1 },
+        })
+      ).toThrow("topP must be no less than 0 (got: -0.1)")
+
+      expect(() =>
+        kurt.generateNaturalLanguage({
+          prompt: "Hello!",
+          sampling: { topP: 1.1 },
+        })
+      ).toThrow("topP must be no greater than 1 (got: 1.1)")
+    })
+
+    test("silently coerces values when violating certain other constraints", () => {
+      const { adapter, kurt } = createV1()
+
+      kurt.generateNaturalLanguage({
+        prompt: "Hello!",
+        sampling: { maxOutputTokens: 1023.5, temperature: 0, topP: 0 },
+      })
+
+      expect(adapter.lastGenerateRawEventsCall?.sampling).toEqual({
+        ...KurtSamplingOptionsDefault,
+        maxOutputTokens: 1024,
+        temperature: Number.MIN_VALUE,
+        topP: Number.MIN_VALUE,
+      })
+    })
+  })
+})

--- a/packages/kurt/src/KurtAdapter.ts
+++ b/packages/kurt/src/KurtAdapter.ts
@@ -1,4 +1,4 @@
-import type { KurtMessage } from "./Kurt"
+import type { KurtMessage, KurtSamplingOptions } from "./Kurt"
 import type { KurtStreamEvent } from "./KurtStream"
 import type {
   KurtSchema,
@@ -47,6 +47,7 @@ export interface KurtAdapterV1<A extends V1TypeParams = V1TypeParams> {
 
   generateRawEvents(options: {
     messages: A["rawMessage"][]
+    sampling: Required<KurtSamplingOptions>
     tools: { [key: string]: A["rawTool"] }
     forceTool?: string
   }): AsyncIterable<A["rawEvent"]>


### PR DESCRIPTION
This commit adds a `KurtSamplingOptions` type with various tweakable values and a `KurtSamplingOptionsDefault` constant with the default values to use when not given.

The `sampling` key can be used to specify sampling options on creation, and/or on individual generate calls. See the docs and tests for more details on what settings are possible and how they behave.

A future PR will update the adapter libraries to start making use of these values.