### PR TITLE
feat: add new OpenAI model: gpt-4o

### DIFF
--- a/packages/kurt-open-ai/spec/KurtOpenAI.spec.ts
+++ b/packages/kurt-open-ai/spec/KurtOpenAI.spec.ts
@@ -48,6 +48,8 @@ describe("KurtOpenAI", () => {
   test("isSupportedModel", () => {
     // For updating this test, the current list of models can be found at:
     // https://platform.openai.com/docs/models/overview
+    expect(KurtOpenAI.isSupportedModel("gpt-4o")).toBe(true)
+    expect(KurtOpenAI.isSupportedModel("gpt-4o-2024-05-13")).toBe(true)
     expect(KurtOpenAI.isSupportedModel("gpt-4-turbo")).toBe(true)
     expect(KurtOpenAI.isSupportedModel("gpt-4-turbo-2024-04-09")).toBe(true)
     expect(KurtOpenAI.isSupportedModel("gpt-4-turbo-preview")).toBe(true)

--- a/packages/kurt-open-ai/src/KurtOpenAI.ts
+++ b/packages/kurt-open-ai/src/KurtOpenAI.ts
@@ -24,6 +24,8 @@ import type {
 
 // These models support function calling.
 const COMPATIBLE_MODELS = [
+  "gpt-4o",
+  "gpt-4o-2024-05-13",
   "gpt-4-turbo",
   "gpt-4-turbo-2024-04-09",
   "gpt-4-turbo-preview",


### PR DESCRIPTION
This model was just released this week, and is said to be cheaper and faster, while still performing well.

The docs say it can do function calling, so it is being added here as supported by Kurt.