### PR TITLE
fix: account for changes in VertexAI chunking behavior

### DIFF
--- a/packages/kurt-vertex-ai/spec/KurtVertexAI.spec.ts
+++ b/packages/kurt-vertex-ai/spec/KurtVertexAI.spec.ts
@@ -99,6 +99,12 @@ describe("KurtVertexAI", () => {
             role: "model",
             parts: [{ text: " How can I help you today?" }],
           },
+        },
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "" }],
+          },
           // biome-ignore lint/suspicious/noExplicitAny: TODO: no any
           finishReason: "STOP" as any,
         },
@@ -164,6 +170,12 @@ describe("KurtVertexAI", () => {
                 },
               },
             ],
+          },
+        },
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "" }],
           },
           // biome-ignore lint/suspicious/noExplicitAny: TODO: no any
           finishReason: "STOP" as any,
@@ -238,6 +250,12 @@ describe("KurtVertexAI", () => {
               },
             ],
           },
+        },
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "" }],
+          },
           // biome-ignore lint/suspicious/noExplicitAny: TODO: no any
           finishReason: "STOP" as any,
         },
@@ -310,6 +328,12 @@ describe("KurtVertexAI", () => {
                 },
               },
             ],
+          },
+        },
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "" }],
           },
           // biome-ignore lint/suspicious/noExplicitAny: TODO: no any
           finishReason: "STOP" as any,
@@ -407,6 +431,12 @@ describe("KurtVertexAI", () => {
                 },
               },
             ],
+          },
+        },
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "" }],
           },
           // biome-ignore lint/suspicious/noExplicitAny: TODO: no any
           finishReason: "STOP" as any,
@@ -532,6 +562,12 @@ describe("KurtVertexAI", () => {
           content: {
             role: "model",
             parts: [{ text: ", rounded to the nearest integer, is 324." }],
+          },
+        },
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "" }],
           },
           // biome-ignore lint/suspicious/noExplicitAny: TODO: no any
           finishReason: "STOP" as any,

--- a/packages/kurt-vertex-ai/src/KurtVertexAI.ts
+++ b/packages/kurt-vertex-ai/src/KurtVertexAI.ts
@@ -205,7 +205,8 @@ async function* transformStream<
 
     for (const [partIndex, part] of parts.entries()) {
       const chunk = part.text
-      const isFinal = isContentFinal && partIndex === parts.length - 1
+      const isFinal =
+        (isContentFinal && partIndex === parts.length - 1) || part.functionCall
 
       if (chunk) {
         chunks.push(chunk)
@@ -229,6 +230,7 @@ async function* transformStream<
           const text = chunks.join("")
           yield { finished: true, text, data: undefined } as KurtStreamEvent<D>
         }
+        return // No need to send more events once we've sent a finished event
       }
     }
   }
@@ -253,7 +255,8 @@ async function* transformStreamWithOptionalTools<
 
     for (const [partIndex, part] of parts.entries()) {
       const chunk = part.text
-      const isFinal = isContentFinal && partIndex === parts.length - 1
+      const isFinal =
+        (isContentFinal && partIndex === parts.length - 1) || part.functionCall
 
       if (chunk) {
         chunks.push(chunk)
@@ -282,6 +285,7 @@ async function* transformStreamWithOptionalTools<
           const text = chunks.join("")
           yield { finished: true, text, data: undefined }
         }
+        return // No need to send more events once we've sent a finished event
       }
     }
   }


### PR DESCRIPTION
VertexAI has quietly changed the behavior of how the "final" event in a stream is represented. Previously, VertexAI would mark the stop reason on the same event as the final chunk of text or function call. Now VertexAI is sending a separate stop event with empty text, which was breaking our mechanism for handling tool calls.

This PR updates the tests and our event handling logic to account for this change in behavior.