### PR TITLE
feat: pass KurtSamplingOptions to the underlying LLM provider

### DIFF
--- a/packages/kurt-open-ai/spec/generateNaturalLanguage.spec.ts
+++ b/packages/kurt-open-ai/spec/generateNaturalLanguage.spec.ts
@@ -10,4 +10,24 @@ describe("KurtOpenAI generateNaturalLanguage", () => {
     )
     expect(result.text).toEqual("Hello! How can I assist you today?")
   })
+
+  test("writes a haiku with high temperature", async () => {
+    const result = await snapshotAndMock((kurt) =>
+      kurt.generateNaturalLanguage({
+        prompt: "Compose a haiku about a mountain stream at night.",
+        sampling: {
+          maxOutputTokens: 100,
+          temperature: 1.0,
+          topP: 1.0,
+        },
+      })
+    )
+    expect(result.text).toEqual(
+      [
+        "Shaft of moonlight glows",
+        "Mountain stream flows silently",
+        "Nature's lullaby",
+      ].join("\n")
+    )
+  })
 })

--- a/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateNaturalLanguage_says_hello.yaml
+++ b/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateNaturalLanguage_says_hello.yaml
@@ -1,6 +1,9 @@
 step1Request:
   stream: true
   model: gpt-3.5-turbo-0125
+  max_tokens: 4096
+  temperature: 0.5
+  top_p: 0.95
   messages:
     - role: user
       content: Say hello!

--- a/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateNaturalLanguage_writes_a_haiku_with_high_temperature.yaml
+++ b/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateNaturalLanguage_writes_a_haiku_with_high_temperature.yaml
@@ -1,0 +1,134 @@
+step1Request:
+  stream: true
+  model: gpt-3.5-turbo-0125
+  max_tokens: 100
+  temperature: 1
+  top_p: 1
+  messages:
+    - role: user
+      content: Compose a haiku about a mountain stream at night.
+step2RawChunks:
+  - index: 0
+    delta:
+      role: assistant
+      content: ""
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: Sha
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: ft
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " of"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " moon"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: light
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " gl"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: ows
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "\n"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: Mountain
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " stream"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " flows"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " silently"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "\n"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: Nature
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "'s"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " l"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: ull
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: aby
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta: {}
+    logprobs: null
+    finish_reason: stop
+step3KurtEvents:
+  - chunk: Sha
+  - chunk: ft
+  - chunk: " of"
+  - chunk: " moon"
+  - chunk: light
+  - chunk: " gl"
+  - chunk: ows
+  - chunk: "\n"
+  - chunk: Mountain
+  - chunk: " stream"
+  - chunk: " flows"
+  - chunk: " silently"
+  - chunk: "\n"
+  - chunk: Nature
+  - chunk: "'s"
+  - chunk: " l"
+  - chunk: ull
+  - chunk: aby
+  - finished: true
+    text: |-
+      Shaft of moonlight glows
+      Mountain stream flows silently
+      Nature's lullaby

--- a/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateStructuredData_says_hello.yaml
+++ b/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateStructuredData_says_hello.yaml
@@ -1,6 +1,9 @@
 step1Request:
   stream: true
   model: gpt-3.5-turbo-0125
+  max_tokens: 4096
+  temperature: 0.5
+  top_p: 0.95
   messages:
     - role: user
       content: Say hello!

--- a/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateWithOptionalTools_calculator_(after_tool_call).yaml
+++ b/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateWithOptionalTools_calculator_(after_tool_call).yaml
@@ -1,6 +1,9 @@
 step1Request:
   stream: true
   model: gpt-3.5-turbo-0125
+  max_tokens: 4096
+  temperature: 0.5
+  top_p: 0.95
   messages:
     - role: user
       content: What's 9876356 divided by 30487, rounded to the nearest integer?

--- a/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateWithOptionalTools_calculator_(with_tool_call).yaml
+++ b/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateWithOptionalTools_calculator_(with_tool_call).yaml
@@ -1,6 +1,9 @@
 step1Request:
   stream: true
   model: gpt-3.5-turbo-0125
+  max_tokens: 4096
+  temperature: 0.5
+  top_p: 0.95
   messages:
     - role: user
       content: What's 9876356 divided by 30487, rounded to the nearest integer?

--- a/packages/kurt-open-ai/src/KurtOpenAI.ts
+++ b/packages/kurt-open-ai/src/KurtOpenAI.ts
@@ -12,6 +12,7 @@ import type {
   KurtSchemaResult,
   KurtSchemaResultMaybe,
   KurtSchema,
+  KurtSamplingOptions,
 } from "@formula-monks/kurt"
 import type {
   OpenAI,
@@ -83,12 +84,16 @@ export class KurtOpenAI
 
   generateRawEvents(options: {
     messages: OpenAIMessage[]
+    sampling: Required<KurtSamplingOptions>
     tools: { [key: string]: OpenAITool }
     forceTool?: string
   }): AsyncIterable<OpenAIResponseChunk> {
     const req: OpenAIRequest = {
       stream: true,
       model: this.options.model,
+      max_tokens: options.sampling.maxOutputTokens,
+      temperature: options.sampling.temperature,
+      top_p: options.sampling.topP,
       messages: options.messages,
     }
 

--- a/packages/kurt-vertex-ai/spec/generateNaturalLanguage.spec.ts
+++ b/packages/kurt-vertex-ai/spec/generateNaturalLanguage.spec.ts
@@ -10,4 +10,24 @@ describe("KurtVertexAI generateNaturalLanguage", () => {
     )
     expect(result.text).toEqual("Hello! How can I assist you today?")
   })
+
+  test("writes a haiku with high temperature", async () => {
+    const result = await snapshotAndMock((kurt) =>
+      kurt.generateNaturalLanguage({
+        prompt: "Compose a haiku about a mountain stream at night.",
+        sampling: {
+          maxOutputTokens: 100,
+          temperature: 1.0,
+          topP: 1.0,
+        },
+      })
+    )
+    expect(result.text).toEqual(
+      [
+        "Moon paints silver path,",
+        "Water sings to sleeping stones,",
+        "Night sighs on the wind.",
+      ].join("\n")
+    )
+  })
 })

--- a/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateNaturalLanguage_says_hello.yaml
+++ b/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateNaturalLanguage_says_hello.yaml
@@ -1,4 +1,8 @@
 step1Request:
+  generationConfig:
+    maxOutputTokens: 4096
+    temperature: 0.5
+    topP: 0.95
   contents:
     - role: user
       parts:

--- a/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateNaturalLanguage_writes_a_haiku_with_high_temperature.yaml
+++ b/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateNaturalLanguage_writes_a_haiku_with_high_temperature.yaml
@@ -1,0 +1,48 @@
+step1Request:
+  generationConfig:
+    maxOutputTokens: 100
+    temperature: 1
+    topP: 1
+  contents:
+    - role: user
+      parts:
+        - text: Compose a haiku about a mountain stream at night.
+step2RawChunks:
+  - content:
+      role: model
+      parts:
+        - text: Moon
+    index: 0
+  - content:
+      role: model
+      parts:
+        - text: |2-
+             paints silver path,
+            Water sings to sleeping stones,
+            Night sighs on the
+    index: 0
+  - content:
+      role: model
+      parts:
+        - text: |2-
+             wind.
+    index: 0
+  - content:
+      role: model
+      parts:
+        - text: ""
+    finishReason: STOP
+    index: 0
+step3KurtEvents:
+  - chunk: Moon
+  - chunk: |2-
+       paints silver path,
+      Water sings to sleeping stones,
+      Night sighs on the
+  - chunk: |2-
+       wind.
+  - finished: true
+    text: |-
+      Moon paints silver path,
+      Water sings to sleeping stones,
+      Night sighs on the wind.

--- a/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateStructuredData_says_hello_(response_format_1).yaml
+++ b/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateStructuredData_says_hello_(response_format_1).yaml
@@ -1,4 +1,8 @@
 step1Request:
+  generationConfig:
+    maxOutputTokens: 4096
+    temperature: 0.5
+    topP: 0.95
   contents:
     - role: user
       parts:

--- a/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateStructuredData_says_hello_(response_format_2).yaml
+++ b/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateStructuredData_says_hello_(response_format_2).yaml
@@ -1,4 +1,8 @@
 step1Request:
+  generationConfig:
+    maxOutputTokens: 4096
+    temperature: 0.5
+    topP: 0.95
   contents:
     - role: user
       parts:

--- a/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateStructuredData_says_hello_(response_format_3).yaml
+++ b/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateStructuredData_says_hello_(response_format_3).yaml
@@ -1,4 +1,8 @@
 step1Request:
+  generationConfig:
+    maxOutputTokens: 4096
+    temperature: 0.5
+    topP: 0.95
   contents:
     - role: user
       parts:

--- a/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateWithOptionalTools_calculator_(after_tool_call).yaml
+++ b/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateWithOptionalTools_calculator_(after_tool_call).yaml
@@ -1,4 +1,8 @@
 step1Request:
+  generationConfig:
+    maxOutputTokens: 4096
+    temperature: 0.5
+    topP: 0.95
   contents:
     - role: user
       parts:

--- a/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateWithOptionalTools_calculator_(with_tool_call).yaml
+++ b/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateWithOptionalTools_calculator_(with_tool_call).yaml
@@ -1,4 +1,8 @@
 step1Request:
+  generationConfig:
+    maxOutputTokens: 4096
+    temperature: 0.5
+    topP: 0.95
   contents:
     - role: user
       parts:

--- a/packages/kurt-vertex-ai/src/KurtVertexAI.ts
+++ b/packages/kurt-vertex-ai/src/KurtVertexAI.ts
@@ -14,6 +14,7 @@ import type {
   KurtSchemaResult,
   KurtSchemaResultMaybe,
   KurtMessage,
+  KurtSamplingOptions,
 } from "@formula-monks/kurt"
 import type {
   VertexAI,
@@ -74,6 +75,7 @@ export class KurtVertexAI
 
   generateRawEvents(options: {
     messages: VertexAIMessage[]
+    sampling: Required<KurtSamplingOptions>
     tools: { [key: string]: VertexAITool }
     forceTool?: string | undefined
   }): AsyncIterable<VertexAIResponseChunk> {
@@ -81,7 +83,14 @@ export class KurtVertexAI
       model: this.options.model,
     }) as VertexAIGenerativeModel
 
-    const req: VertexAIRequest = { contents: options.messages }
+    const req: VertexAIRequest = {
+      generationConfig: {
+        maxOutputTokens: options.sampling.maxOutputTokens,
+        temperature: options.sampling.temperature,
+        topP: options.sampling.topP,
+      },
+      contents: options.messages,
+    }
 
     const tools = Object.values(options.tools)
     if (tools.length > 0) req.tools = [{ functionDeclarations: tools }]


### PR DESCRIPTION
This is a followup to PR #24, which added `KurtSamplingOptions` to the `Kurt` class.

Now, with this PR, the LLM-specific adapters (`KurtOpenAI` and `KurtVertexAI`) will now pass these options along to the underlying LLM provider, in the appropriate adapted way.

This commit also adds tests which demonstrate the passing of these options.