### PR TITLE
feat: support parallel tool calls in `KurtOpenAI` with `generateWithOptionalTools`

### DIFF
--- a/packages/kurt-open-ai/spec/generateWithOptionalTools.spec.ts
+++ b/packages/kurt-open-ai/spec/generateWithOptionalTools.spec.ts
@@ -2,32 +2,35 @@ import { describe, test, expect } from "@jest/globals"
 import { z } from "zod"
 import { snapshotAndMock } from "./snapshots"
 
+const calculatorTools = {
+  subtract: z
+    .object({
+      minuend: z.number().describe("The number to subtract from"),
+      subtrahend: z.number().describe("The number to subtract by"),
+    })
+    .describe("Calculate a subtraction"),
+  divide: z
+    .object({
+      dividend: z.number().describe("The number to be divided"),
+      divisor: z.number().describe("The number to divide by"),
+    })
+    .describe("Calculate a division"),
+}
+
 describe("KurtOpenAI generateWithOptionalTools", () => {
   test("calculator (with tool call)", async () => {
     const result = await snapshotAndMock((kurt) =>
       kurt.generateWithOptionalTools({
         prompt:
           "What's 9876356 divided by 30487, rounded to the nearest integer?",
-        tools: {
-          subtract: z
-            .object({
-              minuend: z.number().describe("The number to subtract from"),
-              subtrahend: z.number().describe("The number to subtract by"),
-            })
-            .describe("Calculate a subtraction"),
-          divide: z
-            .object({
-              dividend: z.number().describe("The number to be divided"),
-              divisor: z.number().describe("The number to divide by"),
-            })
-            .describe("Calculate a division"),
-        },
+        tools: calculatorTools,
       })
     )
     expect(result.data).toEqual({
       name: "divide",
       args: { dividend: 9876356, divisor: 30487 },
     })
+    expect(result.additionalData).toBeUndefined() // no parallel tool calls
   })
 
   test("calculator (after tool call)", async () => {
@@ -35,23 +38,10 @@ describe("KurtOpenAI generateWithOptionalTools", () => {
       kurt.generateWithOptionalTools({
         prompt:
           "What's 9876356 divided by 30487, rounded to the nearest integer?",
-        tools: {
-          subtract: z
-            .object({
-              minuend: z.number().describe("The number to subtract from"),
-              subtrahend: z.number().describe("The number to subtract by"),
-            })
-            .describe("Calculate a subtraction"),
-          divide: z
-            .object({
-              dividend: z.number().describe("The number to be divided"),
-              divisor: z.number().describe("The number to divide by"),
-            })
-            .describe("Calculate a division"),
-        },
+        tools: calculatorTools,
         extraMessages: [
           {
-            role: "model" as const,
+            role: "model",
             toolCall: {
               name: "divide",
               args: { dividend: 9876356, divisor: 30487 },
@@ -63,6 +53,82 @@ describe("KurtOpenAI generateWithOptionalTools", () => {
     )
     expect(result.text).toEqual(
       "Rounded to the nearest integer, the result is 324."
+    )
+  })
+
+  test("calculator (with parallel tool calls)", async () => {
+    const result = await snapshotAndMock((kurt) =>
+      kurt.generateWithOptionalTools({
+        prompt: [
+          "Calculate each of the following:",
+          "1. 8026256882 divided by 3402398",
+          "2. 1185835515 divided by 348263",
+          "3. 90135094495 minus 89944954350",
+        ].join("\n"),
+        tools: calculatorTools,
+      })
+    )
+    expect(result.data).toEqual({
+      name: "divide",
+      args: { dividend: 8026256882, divisor: 3402398 },
+    })
+    expect(result.additionalData).toEqual([
+      {
+        name: "divide",
+        args: { dividend: 1185835515, divisor: 348263 },
+      },
+      {
+        name: "subtract",
+        args: { minuend: 90135094495, subtrahend: 89944954350 },
+      },
+    ])
+  })
+
+  test("calculator (after parallel tool calls)", async () => {
+    const result = await snapshotAndMock((kurt) =>
+      kurt.generateWithOptionalTools({
+        prompt: [
+          "Calculate each of the following:",
+          "1. 8026256882 divided by 3402398",
+          "2. 1185835515 divided by 348263",
+          "3. 90135094495 minus 89944954350",
+        ].join("\n"),
+        tools: calculatorTools,
+        extraMessages: [
+          {
+            role: "model",
+            toolCall: {
+              name: "divide",
+              args: { dividend: 8026256882, divisor: 3402398 },
+              result: { quotient: 2359 },
+            },
+          },
+          {
+            role: "model",
+            toolCall: {
+              name: "divide",
+              args: { dividend: 1185835515, divisor: 348263 },
+              result: { quotient: 3405 },
+            },
+          },
+          {
+            role: "model",
+            toolCall: {
+              name: "subtract",
+              args: { minuend: 90135094495, subtrahend: 89944954350 },
+              result: { quotient: 190140145 },
+            },
+          },
+        ],
+      })
+    )
+    expect(result.text).toEqual(
+      [
+        "The results are:",
+        "1. 8026256882 divided by 3402398 is 2359",
+        "2. 1185835515 divided by 348263 is 3405",
+        "3. 90135094495 minus 89944954350 is 190140145",
+      ].join("\n")
     )
   })
 })

--- a/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateWithOptionalTools_calculator_(after_parallel_tool_calls).yaml
+++ b/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateWithOptionalTools_calculator_(after_parallel_tool_calls).yaml
@@ -1,0 +1,444 @@
+step1Request:
+  stream: true
+  model: gpt-3.5-turbo-0125
+  max_tokens: 4096
+  temperature: 0.5
+  top_p: 0.95
+  messages:
+    - role: user
+      content: |-
+        Calculate each of the following:
+        1. 8026256882 divided by 3402398
+        2. 1185835515 divided by 348263
+        3. 90135094495 minus 89944954350
+    - role: assistant
+      tool_calls:
+        - id: call_1
+          type: function
+          function:
+            name: divide
+            arguments: '{"dividend":8026256882,"divisor":3402398}'
+    - role: tool
+      tool_call_id: call_1
+      content: '{"quotient":2359}'
+    - role: assistant
+      tool_calls:
+        - id: call_2
+          type: function
+          function:
+            name: divide
+            arguments: '{"dividend":1185835515,"divisor":348263}'
+    - role: tool
+      tool_call_id: call_2
+      content: '{"quotient":3405}'
+    - role: assistant
+      tool_calls:
+        - id: call_3
+          type: function
+          function:
+            name: subtract
+            arguments: '{"minuend":90135094495,"subtrahend":89944954350}'
+    - role: tool
+      tool_call_id: call_3
+      content: '{"quotient":190140145}'
+  tools:
+    - type: function
+      function:
+        name: subtract
+        description: Calculate a subtraction
+        parameters:
+          type: object
+          properties:
+            minuend:
+              type: number
+              description: The number to subtract from
+            subtrahend:
+              type: number
+              description: The number to subtract by
+          required:
+            - minuend
+            - subtrahend
+          additionalProperties: false
+          description: Calculate a subtraction
+          $schema: http://json-schema.org/draft-07/schema#
+    - type: function
+      function:
+        name: divide
+        description: Calculate a division
+        parameters:
+          type: object
+          properties:
+            dividend:
+              type: number
+              description: The number to be divided
+            divisor:
+              type: number
+              description: The number to divide by
+          required:
+            - dividend
+            - divisor
+          additionalProperties: false
+          description: Calculate a division
+          $schema: http://json-schema.org/draft-07/schema#
+step2RawChunks:
+  - index: 0
+    delta:
+      role: assistant
+      content: ""
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: The
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " results"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " are"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: |
+        :
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "1"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: .
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " "
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "802"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "625"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "688"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "2"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " divided"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " by"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " "
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "340"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "239"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "8"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " is"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " "
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "235"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "9"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "\n"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "2"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: .
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " "
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "118"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "583"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "551"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "5"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " divided"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " by"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " "
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "348"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "263"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " is"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " "
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "340"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "5"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "\n"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "3"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: .
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " "
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "901"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "350"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "944"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "95"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " minus"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " "
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "899"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "449"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "543"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "50"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " is"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: " "
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "190"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "140"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      content: "145"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta: {}
+    logprobs: null
+    finish_reason: stop
+step3KurtEvents:
+  - chunk: The
+  - chunk: " results"
+  - chunk: " are"
+  - chunk: |
+      :
+  - chunk: "1"
+  - chunk: .
+  - chunk: " "
+  - chunk: "802"
+  - chunk: "625"
+  - chunk: "688"
+  - chunk: "2"
+  - chunk: " divided"
+  - chunk: " by"
+  - chunk: " "
+  - chunk: "340"
+  - chunk: "239"
+  - chunk: "8"
+  - chunk: " is"
+  - chunk: " "
+  - chunk: "235"
+  - chunk: "9"
+  - chunk: "\n"
+  - chunk: "2"
+  - chunk: .
+  - chunk: " "
+  - chunk: "118"
+  - chunk: "583"
+  - chunk: "551"
+  - chunk: "5"
+  - chunk: " divided"
+  - chunk: " by"
+  - chunk: " "
+  - chunk: "348"
+  - chunk: "263"
+  - chunk: " is"
+  - chunk: " "
+  - chunk: "340"
+  - chunk: "5"
+  - chunk: "\n"
+  - chunk: "3"
+  - chunk: .
+  - chunk: " "
+  - chunk: "901"
+  - chunk: "350"
+  - chunk: "944"
+  - chunk: "95"
+  - chunk: " minus"
+  - chunk: " "
+  - chunk: "899"
+  - chunk: "449"
+  - chunk: "543"
+  - chunk: "50"
+  - chunk: " is"
+  - chunk: " "
+  - chunk: "190"
+  - chunk: "140"
+  - chunk: "145"
+  - finished: true
+    text: |-
+      The results are:
+      1. 8026256882 divided by 3402398 is 2359
+      2. 1185835515 divided by 348263 is 3405
+      3. 90135094495 minus 89944954350 is 190140145

--- a/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateWithOptionalTools_calculator_(with_parallel_tool_calls).yaml
+++ b/packages/kurt-open-ai/spec/snapshots/KurtOpenAI_generateWithOptionalTools_calculator_(with_parallel_tool_calls).yaml
@@ -1,0 +1,379 @@
+step1Request:
+  stream: true
+  model: gpt-3.5-turbo-0125
+  max_tokens: 4096
+  temperature: 0.5
+  top_p: 0.95
+  messages:
+    - role: user
+      content: |-
+        Calculate each of the following:
+        1. 8026256882 divided by 3402398
+        2. 1185835515 divided by 348263
+        3. 90135094495 minus 89944954350
+  tools:
+    - type: function
+      function:
+        name: subtract
+        description: Calculate a subtraction
+        parameters:
+          type: object
+          properties:
+            minuend:
+              type: number
+              description: The number to subtract from
+            subtrahend:
+              type: number
+              description: The number to subtract by
+          required:
+            - minuend
+            - subtrahend
+          additionalProperties: false
+          description: Calculate a subtraction
+          $schema: http://json-schema.org/draft-07/schema#
+    - type: function
+      function:
+        name: divide
+        description: Calculate a division
+        parameters:
+          type: object
+          properties:
+            dividend:
+              type: number
+              description: The number to be divided
+            divisor:
+              type: number
+              description: The number to divide by
+          required:
+            - dividend
+            - divisor
+          additionalProperties: false
+          description: Calculate a division
+          $schema: http://json-schema.org/draft-07/schema#
+step2RawChunks:
+  - index: 0
+    delta:
+      role: assistant
+      content: null
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          id: call_3mVJOu69Aewi1MO55KjPxX98
+          type: function
+          function:
+            name: divide
+            arguments: ""
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          function:
+            arguments: '{"di'
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          function:
+            arguments: viden
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          function:
+            arguments: 'd": 80'
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          function:
+            arguments: "2625"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          function:
+            arguments: 6882,
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          function:
+            arguments: ' "divi'
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          function:
+            arguments: sor"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          function:
+            arguments: ": 340"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 0
+          function:
+            arguments: 2398}
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          id: call_9FmCDa3aWw6TnBD84s6D1Zx3
+          type: function
+          function:
+            name: divide
+            arguments: ""
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          function:
+            arguments: '{"di'
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          function:
+            arguments: viden
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          function:
+            arguments: 'd": 11'
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          function:
+            arguments: "8583"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          function:
+            arguments: 5515,
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          function:
+            arguments: ' "divi'
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          function:
+            arguments: sor"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          function:
+            arguments: ": 348"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 1
+          function:
+            arguments: 263}
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          id: call_mNmwVVVBWf7LQfFw7DPSBAfj
+          type: function
+          function:
+            name: subtract
+            arguments: ""
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: '{"mi'
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: nuend
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: '": 901'
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: "3509"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: 4495,
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: ' "subt'
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: rahe
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: 'nd": '
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: "899449"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: "5435"
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta:
+      tool_calls:
+        - index: 2
+          function:
+            arguments: 0}
+    logprobs: null
+    finish_reason: null
+  - index: 0
+    delta: {}
+    logprobs: null
+    finish_reason: tool_calls
+step3KurtEvents:
+  - chunk: '{"di'
+  - chunk: viden
+  - chunk: 'd": 80'
+  - chunk: "2625"
+  - chunk: 6882,
+  - chunk: ' "divi'
+  - chunk: sor"
+  - chunk: ": 340"
+  - chunk: 2398}
+  - chunk: "\n"
+  - chunk: '{"di'
+  - chunk: viden
+  - chunk: 'd": 11'
+  - chunk: "8583"
+  - chunk: 5515,
+  - chunk: ' "divi'
+  - chunk: sor"
+  - chunk: ": 348"
+  - chunk: 263}
+  - chunk: "\n"
+  - chunk: '{"mi'
+  - chunk: nuend
+  - chunk: '": 901'
+  - chunk: "3509"
+  - chunk: 4495,
+  - chunk: ' "subt'
+  - chunk: rahe
+  - chunk: 'nd": '
+  - chunk: "899449"
+  - chunk: "5435"
+  - chunk: 0}
+  - finished: true
+    text: |-
+      {"dividend": 8026256882, "divisor": 3402398}
+      {"dividend": 1185835515, "divisor": 348263}
+      {"minuend": 90135094495, "subtrahend": 89944954350}
+    data:
+      name: divide
+      args:
+        dividend: 8026256882
+        divisor: 3402398
+    additionalData:
+      - name: divide
+        args:
+          dividend: 1185835515
+          divisor: 348263
+      - name: subtract
+        args:
+          minuend: 90135094495
+          subtrahend: 89944954350


### PR DESCRIPTION
This commit updates the `KurtOpenAI` adapter to handle the case of multiple parallel tool calls from the LLM, when being used with the `generateWithOptionalTools` method of `Kurt`.

In theory it would make sense to handle this case for `generateStructuredData` too, but in practice I cannot get OpenAI to respond with parallel tool calls when we are using `tool_choice: { function: {...} }` as we do in that method - it seems as though this option prevents parallel tool calls. If we can get this behavior to surface in practice in the future we can add logic and tests to handle that case.

Note that this resolves part of issue #33 - it resolves it for the OpenAI adapter, but not the Vertex AI adapter.