### PR TITLE
fix: add missing repository information to `package.json`

### DIFF
--- a/packages/kurt-open-ai/package.json
+++ b/packages/kurt-open-ai/package.json
@@ -3,6 +3,12 @@
   "description": "OpenAI plugin for Kurt - A wrapper for AI SDKs, for building LLM-agnostic structured AI applications",
   "license": "MIT",
   "version": "1.0.0",
+  "homepage": "https://github.com/FormulaMonks/kurt",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormulaMonks/kurt.git",
+    "directory": "packages/kurt-open-ai"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": ["dist"],

--- a/packages/kurt-vertex-ai/package.json
+++ b/packages/kurt-vertex-ai/package.json
@@ -3,6 +3,12 @@
   "description": "VertexAI plugin for Kurt - A wrapper for AI SDKs, for building LLM-agnostic structured AI applications",
   "license": "MIT",
   "version": "1.0.0",
+  "homepage": "https://github.com/FormulaMonks/kurt",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormulaMonks/kurt.git",
+    "directory": "packages/kurt-vertex-ai"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": ["dist"],

--- a/packages/kurt/package.json
+++ b/packages/kurt/package.json
@@ -3,6 +3,12 @@
   "description": "A wrapper for AI SDKs, for building LLM-agnostic structured AI applications",
   "license": "MIT",
   "version": "1.0.0",
+  "homepage": "https://github.com/FormulaMonks/kurt",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormulaMonks/kurt.git",
+    "directory": "packages/kurt"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": ["dist"],


### PR DESCRIPTION
This commit sets the `homepage` and `repository` fields in each package's `package.json` to make this repository easily discoverable if starting from npm.