### PR TITLE
feat: support parallel tool calls in `KurtVertexAI` with `generateWithOptionalTools`

### DIFF
--- a/packages/kurt-open-ai/src/KurtOpenAI.ts
+++ b/packages/kurt-open-ai/src/KurtOpenAI.ts
@@ -302,9 +302,9 @@ async function* transformStreamWithOptionalTools<
           } as D
         })
 
-        // biome-ignore lint/style/noNonNullAssertion: we already validated above that length > 0
-        const data = allData[0]!
-        const additionalData = allData.slice(1)
+        if (!isNonEmptyArray(allData))
+          throw new Error("Empty here is impossible but TS doesn't know it")
+        const [data, ...additionalData] = allData
 
         if (additionalData.length > 0) {
           yield { finished: true, text, data, additionalData }
@@ -316,4 +316,12 @@ async function* transformStreamWithOptionalTools<
       }
     }
   }
+}
+
+/**
+ * Return true if this array has at least one element, also refining the
+ * Typescript type to indicate that the first element won't be undefined.
+ */
+function isNonEmptyArray<T>(array: T[]): array is [T, ...T[]] {
+  return array.length > 0
 }

--- a/packages/kurt-vertex-ai/spec/generateWithOptionalTools.spec.ts
+++ b/packages/kurt-vertex-ai/spec/generateWithOptionalTools.spec.ts
@@ -2,26 +2,28 @@ import { describe, test, expect } from "@jest/globals"
 import { z } from "zod"
 import { snapshotAndMock } from "./snapshots"
 
+const calculatorTools = {
+  subtract: z
+    .object({
+      minuend: z.number().describe("The number to subtract from"),
+      subtrahend: z.number().describe("The number to subtract by"),
+    })
+    .describe("Calculate a subtraction"),
+  divide: z
+    .object({
+      dividend: z.number().describe("The number to be divided"),
+      divisor: z.number().describe("The number to divide by"),
+    })
+    .describe("Calculate a division"),
+}
+
 describe("KurtVertexAI generateWithOptionalTools", () => {
   test("calculator (with tool call)", async () => {
     const result = await snapshotAndMock((kurt) =>
       kurt.generateWithOptionalTools({
         prompt:
           "What's 9876356 divided by 30487, rounded to the nearest integer?",
-        tools: {
-          subtract: z
-            .object({
-              minuend: z.number().describe("The number to subtract from"),
-              subtrahend: z.number().describe("The number to subtract by"),
-            })
-            .describe("Calculate a subtraction"),
-          divide: z
-            .object({
-              dividend: z.number().describe("The number to be divided"),
-              divisor: z.number().describe("The number to divide by"),
-            })
-            .describe("Calculate a division"),
-        },
+        tools: calculatorTools,
       })
     )
     expect(result.data).toEqual({
@@ -35,20 +37,7 @@ describe("KurtVertexAI generateWithOptionalTools", () => {
       kurt.generateWithOptionalTools({
         prompt:
           "What's 9876356 divided by 30487, rounded to the nearest integer?",
-        tools: {
-          subtract: z
-            .object({
-              minuend: z.number().describe("The number to subtract from"),
-              subtrahend: z.number().describe("The number to subtract by"),
-            })
-            .describe("Calculate a subtraction"),
-          divide: z
-            .object({
-              dividend: z.number().describe("The number to be divided"),
-              divisor: z.number().describe("The number to divide by"),
-            })
-            .describe("Calculate a division"),
-        },
+        tools: calculatorTools,
         extraMessages: [
           {
             role: "model" as const,
@@ -62,5 +51,81 @@ describe("KurtVertexAI generateWithOptionalTools", () => {
       })
     )
     expect(result.text).toEqual("That's about 324.")
+  })
+
+  test("calculator (with parallel tool calls)", async () => {
+    const result = await snapshotAndMock((kurt) =>
+      kurt.generateWithOptionalTools({
+        prompt: [
+          "Calculate each of the following:",
+          "1. 8026256882 divided by 3402398",
+          "2. 1185835515 divided by 348263",
+          "3. 90135094495 minus 89944954350",
+        ].join("\n"),
+        tools: calculatorTools,
+      })
+    )
+    expect(result.data).toEqual({
+      name: "divide",
+      args: { dividend: 8026256882, divisor: 3402398 },
+    })
+    expect(result.additionalData).toEqual([
+      {
+        name: "divide",
+        args: { dividend: 1185835515, divisor: 348263 },
+      },
+      {
+        name: "subtract",
+        args: { minuend: 90135094495, subtrahend: 89944954350 },
+      },
+    ])
+  })
+
+  test("calculator (after parallel tool calls)", async () => {
+    const result = await snapshotAndMock((kurt) =>
+      kurt.generateWithOptionalTools({
+        prompt: [
+          "Calculate each of the following:",
+          "1. 8026256882 divided by 3402398",
+          "2. 1185835515 divided by 348263",
+          "3. 90135094495 minus 89944954350",
+        ].join("\n"),
+        tools: calculatorTools,
+        extraMessages: [
+          {
+            role: "model",
+            toolCall: {
+              name: "divide",
+              args: { dividend: 8026256882, divisor: 3402398 },
+              result: { quotient: 2359 },
+            },
+          },
+          {
+            role: "model",
+            toolCall: {
+              name: "divide",
+              args: { dividend: 1185835515, divisor: 348263 },
+              result: { quotient: 3405 },
+            },
+          },
+          {
+            role: "model",
+            toolCall: {
+              name: "subtract",
+              args: { minuend: 90135094495, subtrahend: 89944954350 },
+              result: { quotient: 190140145 },
+            },
+          },
+        ],
+      })
+    )
+    expect(result.text).toEqual(
+      [
+        "1. 8026256882 divided by 3402398 is 2359.",
+        "2. 1185835515 divided by 348263 is 3405.",
+        "3. 90135094495 minus 89944954350 is 190140145.",
+        "",
+      ].join("\n")
+    )
   })
 })

--- a/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateWithOptionalTools_calculator_(after_parallel_tool_calls).yaml
+++ b/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateWithOptionalTools_calculator_(after_parallel_tool_calls).yaml
@@ -1,0 +1,141 @@
+step1Request:
+  generationConfig:
+    maxOutputTokens: 4096
+    temperature: 0.5
+    topP: 0.95
+  contents:
+    - role: user
+      parts:
+        - text: |-
+            Calculate each of the following:
+            1. 8026256882 divided by 3402398
+            2. 1185835515 divided by 348263
+            3. 90135094495 minus 89944954350
+    - role: model
+      parts:
+        - functionCall:
+            name: divide
+            args:
+              dividend: 8026256882
+              divisor: 3402398
+    - role: model
+      parts:
+        - functionResponse:
+            name: divide
+            response:
+              quotient: 2359
+    - role: model
+      parts:
+        - functionCall:
+            name: divide
+            args:
+              dividend: 1185835515
+              divisor: 348263
+    - role: model
+      parts:
+        - functionResponse:
+            name: divide
+            response:
+              quotient: 3405
+    - role: model
+      parts:
+        - functionCall:
+            name: subtract
+            args:
+              minuend: 90135094495
+              subtrahend: 89944954350
+    - role: model
+      parts:
+        - functionResponse:
+            name: subtract
+            response:
+              quotient: 190140145
+  tools:
+    - functionDeclarations:
+        - name: subtract
+          description: Calculate a subtraction
+          parameters:
+            type: object
+            properties:
+              minuend:
+                type: number
+                description: The number to subtract from
+              subtrahend:
+                type: number
+                description: The number to subtract by
+            required:
+              - minuend
+              - subtrahend
+        - name: divide
+          description: Calculate a division
+          parameters:
+            type: object
+            properties:
+              dividend:
+                type: number
+                description: The number to be divided
+              divisor:
+                type: number
+                description: The number to divide by
+            required:
+              - dividend
+              - divisor
+step2RawChunks:
+  - content:
+      role: model
+      parts:
+        - text: "1"
+    index: 0
+  - content:
+      role: model
+      parts:
+        - text: . 8026256882 divided by 3
+    index: 0
+  - content:
+      role: model
+      parts:
+        - text: |-
+            402398 is 2359.
+            2.
+    index: 0
+  - content:
+      role: model
+      parts:
+        - text: |2-
+             1185835515 divided by 348263 is 3405.
+            3. 9
+    index: 0
+  - content:
+      role: model
+      parts:
+        - text: 0135094495 minus 89944954350 is 1901401
+    index: 0
+  - content:
+      role: model
+      parts:
+        - text: |
+            45.
+    index: 0
+  - content:
+      role: model
+      parts:
+        - text: ""
+    finishReason: STOP
+    index: 0
+step3KurtEvents:
+  - chunk: "1"
+  - chunk: . 8026256882 divided by 3
+  - chunk: |-
+      402398 is 2359.
+      2.
+  - chunk: |2-
+       1185835515 divided by 348263 is 3405.
+      3. 9
+  - chunk: 0135094495 minus 89944954350 is 1901401
+  - chunk: |
+      45.
+  - finished: true
+    text: |
+      1. 8026256882 divided by 3402398 is 2359.
+      2. 1185835515 divided by 348263 is 3405.
+      3. 90135094495 minus 89944954350 is 190140145.

--- a/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateWithOptionalTools_calculator_(with_parallel_tool_calls).yaml
+++ b/packages/kurt-vertex-ai/spec/snapshots/KurtVertexAI_generateWithOptionalTools_calculator_(with_parallel_tool_calls).yaml
@@ -1,0 +1,88 @@
+step1Request:
+  generationConfig:
+    maxOutputTokens: 4096
+    temperature: 0.5
+    topP: 0.95
+  contents:
+    - role: user
+      parts:
+        - text: |-
+            Calculate each of the following:
+            1. 8026256882 divided by 3402398
+            2. 1185835515 divided by 348263
+            3. 90135094495 minus 89944954350
+  tools:
+    - functionDeclarations:
+        - name: subtract
+          description: Calculate a subtraction
+          parameters:
+            type: object
+            properties:
+              minuend:
+                type: number
+                description: The number to subtract from
+              subtrahend:
+                type: number
+                description: The number to subtract by
+            required:
+              - minuend
+              - subtrahend
+        - name: divide
+          description: Calculate a division
+          parameters:
+            type: object
+            properties:
+              dividend:
+                type: number
+                description: The number to be divided
+              divisor:
+                type: number
+                description: The number to divide by
+            required:
+              - dividend
+              - divisor
+step2RawChunks:
+  - content:
+      role: model
+      parts:
+        - functionCall:
+            name: divide
+            args:
+              dividend: 8026256882
+              divisor: 3402398
+        - functionCall:
+            name: divide
+            args:
+              dividend: 1185835515
+              divisor: 348263
+        - functionCall:
+            name: subtract
+            args:
+              minuend: 90135094495
+              subtrahend: 89944954350
+    index: 0
+step3KurtEvents:
+  - chunk: '{"dividend":8026256882,"divisor":3402398}'
+  - chunk: "\n"
+  - chunk: '{"dividend":1185835515,"divisor":348263}'
+  - chunk: "\n"
+  - chunk: '{"minuend":90135094495,"subtrahend":89944954350}'
+  - finished: true
+    text: |-
+      {"dividend":8026256882,"divisor":3402398}
+      {"dividend":1185835515,"divisor":348263}
+      {"minuend":90135094495,"subtrahend":89944954350}
+    data:
+      name: divide
+      args:
+        dividend: 8026256882
+        divisor: 3402398
+    additionalData:
+      - name: divide
+        args:
+          dividend: 1185835515
+          divisor: 348263
+      - name: subtract
+        args:
+          minuend: 90135094495
+          subtrahend: 89944954350

--- a/packages/kurt-vertex-ai/src/KurtVertexAI.ts
+++ b/packages/kurt-vertex-ai/src/KurtVertexAI.ts
@@ -309,13 +309,13 @@ async function* transformStreamWithOptionalTools<
             yield { chunk: text }
           }
 
-          // biome-ignore lint/style/noNonNullAssertion: we already validated above that length > 0
-          const data = allData[0]!
-          const additionalData = allData.slice(1)
+          if (!isNonEmptyArray(allData))
+            throw new Error("Empty here is impossible but TS doesn't know it")
+          const [data, ...additionalData] = allData
           const text = chunks.join("")
 
           if (additionalData.length > 0) {
-            yield { finished: true, text, data, additionalData }
+            yield { finished: true, text, data: data as D, additionalData }
           } else {
             yield { finished: true, text, data }
           }
@@ -356,4 +356,12 @@ function applySchemaToFuzzyStructure<I extends KurtSchemaInner>(
     // If all the alternative strategies failed, throw the original error.
     throw firstParseError
   }
+}
+
+/**
+ * Return true if this array has at least one element, also refining the
+ * Typescript type to indicate that the first element won't be undefined.
+ */
+function isNonEmptyArray<T>(array: T[]): array is [T, ...T[]] {
+  return array.length > 0
 }


### PR DESCRIPTION
This commit updates the `KurtVertexAI` adapter to handle the case of multiple parallel tool calls from the LLM, when being used with the `generateWithOptionalTools` method of `Kurt`.

Similar to PR #35, this PR resolves part of issue #33