### PR TITLE
fix: ensure `KurtCache` hashes the new `forceSchemaConstrainedTokens` option

### DIFF
--- a/packages/kurt-cache/src/KurtCache.ts
+++ b/packages/kurt-cache/src/KurtCache.ts
@@ -305,6 +305,11 @@ function hashSamplingOptions(digest: Hash, options: KurtSamplingOptions): Hash {
   mayHash(digest, "maxOutputTokens", options.maxOutputTokens)
   mayHash(digest, "temperature", options.temperature)
   mayHash(digest, "topP", options.topP)
+  mayHash(
+    digest,
+    "forceSchemaConstrainedTokens",
+    options.forceSchemaConstrainedTokens
+  )
   return digest
 }
 
@@ -357,10 +362,11 @@ function hashSchema(digest: Hash, schema: KurtSchema<KurtSchemaInner>) {
 function mayHash(
   digest: Hash,
   key: string,
-  value: string | number | undefined
+  value: string | number | boolean | undefined
 ) {
-  if (value === undefined) return
+  if (value === undefined || value === false) return
   digest.update(key)
+  if (value === true) return
   if (typeof value === "string") digest.update(value)
   else digest.update(value.toString())
 }


### PR DESCRIPTION
This ensures that changing the option will correctly cause a cache miss. But leaving it at the default value of `false` won't change existing hashes because `false` is treated as "missing" in the `mayHash` internal function.