### PR TITLE
fix: correctly pass through the `forceTool` option inside `KurtCache.generateRawEvents`

### DIFF
--- a/packages/kurt-cache/spec/KurtCache.spec.ts
+++ b/packages/kurt-cache/spec/KurtCache.spec.ts
@@ -200,6 +200,14 @@ class StubAdapter
     }
     forceTool?: string
   }) {
+    // If there are tools, expect the forceTool to be set, because these tests
+    // don't use the "optional tools" feature. This lets us ensure that the
+    // forceTool is set correctly in the tests that use it.
+    if (Object.keys(options.tools).length > 0) {
+      expect(options.forceTool).toBeDefined()
+    }
+
+    // Emit the next canned response.
     for (const bytes of this.nextCannedResponse()) {
       yield { bytes }
     }

--- a/packages/kurt-cache/src/KurtCache.ts
+++ b/packages/kurt-cache/src/KurtCache.ts
@@ -143,8 +143,8 @@ export class KurtCache<A extends KurtAdapter>
         ),
       },
       adapter.generateRawEvents({
+        ...options,
         messages: adapter.transformToRawMessages(options.messages),
-        sampling: options.sampling,
         tools: Object.fromEntries(
           Object.entries(options.tools).map(([name, tool]) => [
             name,


### PR DESCRIPTION
Prior to this commit, that option was being silently dropped because it was neglected in the new object that gets sent to the internal adapter. This commit introduces a usage of the spread operator to ensure that no such options are dropped (while still allowing the replacement of other options).